### PR TITLE
MaterialGroups: SerializedDictionaryを使ってデータを保持する

### DIFF
--- a/.idea/.idea.MaterialPropertyBaker.dir/.idea/.gitignore
+++ b/.idea/.idea.MaterialPropertyBaker.dir/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/.idea.MaterialPropertyBaker.iml
+/contentModel.xml
+/projectSettingsUpdater.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.MaterialPropertyBaker.dir/.idea/encodings.xml
+++ b/.idea/.idea.MaterialPropertyBaker.dir/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/.idea.MaterialPropertyBaker.dir/.idea/indexLayout.xml
+++ b/.idea/.idea.MaterialPropertyBaker.dir/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.MaterialPropertyBaker.dir/.idea/vcs.xml
+++ b/.idea/.idea.MaterialPropertyBaker.dir/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Editor/MaterialGroupsEditor.cs
+++ b/Editor/MaterialGroupsEditor.cs
@@ -1,38 +1,39 @@
 using UnityEditor;
 using UnityEngine;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace sui4.MaterialPropertyBaker
 {
     [CustomEditor(typeof(MaterialGroups))]
     public class MaterialGroupsEditor: Editor
     {
+        // serialized property of MaterialGroups(target)
+        private SerializedProperty _renderers;
+        private SerializedProperty _materialStatusSDictSDict;
         private SerializedProperty _defaultProfile;
         private SerializedProperty _materialPropertyConfig;
-        private SerializedProperty _materialStatusListList;
 
-        private SerializedProperty _materialStatusList;
-        private SerializedProperty _materialStatues;
-        private SerializedProperty _renderer;
+        private MaterialGroups Target => (MaterialGroups)target;
         private void OnEnable()
         {
             _defaultProfile = serializedObject.FindProperty("_overrideOverrideDefaultPreset");
             _materialPropertyConfig = serializedObject.FindProperty("_materialPropertyConfig");
-            _materialStatusListList = serializedObject.FindProperty("_materialStatusListList");
+            _materialStatusSDictSDict = serializedObject.FindProperty("_materialStatusDictDict");
+            _renderers = serializedObject.FindProperty("_renderers");
         }
 
         public override void OnInspectorGUI()
         {
             // base.OnInspectorGUI();
-
             serializedObject.Update();
-           
-            var mg = (MaterialGroups)target;
-            if (mg == null)
+            if (Target == null)
                 return;
 
             // default
             using (var change = new EditorGUI.ChangeCheckScope())
             {
+                EditorGUILayout.PropertyField(_materialStatusSDictSDict);
                 EditorGUILayout.PropertyField(_materialPropertyConfig);
                 EditorGUILayout.Separator();
                 
@@ -48,111 +49,120 @@ namespace sui4.MaterialPropertyBaker
             using (new EditorGUILayout.VerticalScope("box"))
             {
                 EditorGUILayout.LabelField("Renderers", new GUIStyle("label"));
-                for(int i=0; i < _materialStatusListList.arraySize; i++)
+                for(int i=0; i < _renderers.arraySize; i++)
                 {
-                    
-                    _materialStatusList = _materialStatusListList.GetArrayElementAtIndex(i);
+                    var rendererProp = _renderers.GetArrayElementAtIndex(i);
                     using (new EditorGUILayout.VerticalScope("box"))
                     {
-                        RendererGUI(_materialStatusList, i);
+                        RendererGUI(rendererProp, i);
                     }
                     EditorGUILayout.Separator();
                 }
                 // Add Renderer button
                 if (GUILayout.Button("+"))
                 {
-                    var matStatusList = new MaterialStatusList();
-                    mg.MaterialStatusListList.Add(matStatusList);
-                    EditorUtility.SetDirty(mg);
-                    serializedObject.ApplyModifiedProperties();
+                    Target.Renderers.Add(null);
+                    EditorUtility.SetDirty(Target);
+                    serializedObject.Update();
                 }
             }
         }
         
         // ri = renderer index
-        private void RendererGUI(SerializedProperty listlistProp, int ri)
+        private void RendererGUI(SerializedProperty rendererProp, int ri)
         {
-            var mg = (MaterialGroups)target;
-            _materialStatues = listlistProp.FindPropertyRelative("_materialStatuses");
-            _renderer = listlistProp.FindPropertyRelative("_renderer");
+            var currentRenderer = rendererProp.objectReferenceValue as Renderer;
             
             using (new GUILayout.HorizontalScope())
             {
                 using (var change = new EditorGUI.ChangeCheckScope())
                 {
-                    EditorGUILayout.ObjectField(_renderer);
+                    EditorGUILayout.PropertyField(rendererProp, new GUIContent("Renderer"));
                     if (change.changed)
                     {
-                        serializedObject.ApplyModifiedProperties();
-                        if (_renderer.objectReferenceValue != null)
+                        var newRenderer = rendererProp.objectReferenceValue as Renderer;
+                        if (Target.Renderers.Contains(newRenderer))
                         {
-                            var ren = (Renderer)_renderer.objectReferenceValue;
-                            mg.MaterialStatusListList[ri].Renderer = ren;
-                            mg.MaterialStatusListList[ri].MaterialStatuses.Clear();
-                            for(int mi = 0; mi < ren.sharedMaterials.Length; mi++)
-                            {
-                                var mat = ren.sharedMaterials[mi];
-                                var matStatus = new MaterialStatus();
-                                matStatus.Material = mat;
-                                matStatus.IsTarget = true;
-                                mg.MaterialStatusListList[ri].MaterialStatuses.Add(matStatus);
-                            }
-                            Debug.Log("Added" + ren.sharedMaterials.Length);
+                            Debug.LogWarning($"this renderer is already added to MaterialGroups {target.name}. so skipped.");
                         }
                         else
                         {
-                            mg.MaterialStatusListList[ri].MaterialStatuses.Clear();
+                            if (currentRenderer != null)
+                            {
+                                Target.MaterialStatusDictDict.Remove(currentRenderer);
+                            }
+                        
+                            if (newRenderer != null)
+                            {
+                                var materialStatusDictWrapperToAdd = new MaterialStatusDictWrapper();
+
+                                foreach (var mat in newRenderer.sharedMaterials)
+                                {
+                                    if (!materialStatusDictWrapperToAdd.MaterialStatusDict.TryAdd(mat, true))
+                                    {
+                                        // failed to add
+                                        Debug.LogWarning($"MaterialGroups: Failed to add material to MaterialStatusDict {target.name}");
+                                    }
+                                }
+                                Target.MaterialStatusDictDict.TryAdd(newRenderer, materialStatusDictWrapperToAdd);
+                                Debug.Log($"Added {newRenderer.sharedMaterials.Length} materials to MaterialGroups of {target.name}");
+                            }
                         }
+                        Target.Renderers[ri] = newRenderer;
+                        EditorUtility.SetDirty(Target);
                         serializedObject.Update();
 
                     }
                 }
                 if(GUILayout.Button("-", GUILayout.Width(25)))
                 {
-                    mg.MaterialStatusListList[ri].MaterialStatuses.Clear();
-                    mg.MaterialStatusListList[ri].Renderer = null;
-                    mg.MaterialStatusListList.RemoveAt(ri);
-                    EditorUtility.SetDirty(mg);
+                    if (currentRenderer != null)
+                    {
+                        Target.MaterialStatusDictDict.Remove(currentRenderer);
+                    }
+                    Target.Renderers.RemoveAt(ri);
+                    EditorUtility.SetDirty(Target);
                     serializedObject.Update();
                     return;
                 }
             }
 
-            var renderer = mg.MaterialStatusListList[ri].Renderer;
-            if(renderer == null) return;
-
-            var mats = renderer.sharedMaterials;
+            currentRenderer = rendererProp.objectReferenceValue as Renderer;
+            if(currentRenderer == null) return;
             
             EditorGUI.indentLevel++;
-            for (int mi = 0; mi < _materialStatues.arraySize; mi++)
+            var hasValue = Target.MaterialStatusDictDict.TryGetValue(currentRenderer, out var materialStatusDictWrapper);
+            if (hasValue)
             {
-                int index = mg.GetIndex(ri, mi);
-                var mat = mats[mi];
-                SerializedProperty matStatusProp = _materialStatues.GetArrayElementAtIndex(mi);
-                
-                SerializedProperty matProp = matStatusProp.FindPropertyRelative("_material");
-                SerializedProperty isTargetProp = matStatusProp.FindPropertyRelative("_isTarget");
-                using (new EditorGUILayout.HorizontalScope())
+                // foreachで回すと、要素の変更時にエラーが出るので、forで回す
+                // 今回ここでは要素数を変えないため、index out of rangeは起きない
+                for (int mi = 0; mi < materialStatusDictWrapper.MaterialStatusDict.Count; mi++)
                 {
-                    using (var change = new EditorGUI.ChangeCheckScope())
-                    {
-                        EditorGUILayout.LabelField("Apply", GUILayout.Width(60));
-                        EditorGUILayout.PropertyField(isTargetProp, label:new GUIContent());
-                        if (change.changed)
-                        {
-                            serializedObject.ApplyModifiedProperties();
-                        }
-                    }
-
-                    using (new EditorGUI.DisabledScope())
-                    {
-                        EditorGUILayout.PropertyField(matProp, label:new GUIContent());
-                    }
+                    var kvp = materialStatusDictWrapper.MaterialStatusDict.ElementAt(mi);
+                    MaterialGUI(kvp.Key, kvp.Value, ref materialStatusDictWrapper);
                 }
             }
-
-
             EditorGUI.indentLevel--;
+        }
+
+        private void MaterialGUI(Material material, bool isTarget, ref MaterialStatusDictWrapper materialStatusDictWrapper)
+        {
+            // Caution: 要素数が変わるとエラーが出るので、要素数を変えないようにする
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                using (var change = new EditorGUI.ChangeCheckScope())
+                {
+                    var newValue = EditorGUILayout.ToggleLeft("Apply", isTarget);
+                    if (change.changed)
+                    {
+                        materialStatusDictWrapper.MaterialStatusDict[material] = newValue;
+                        serializedObject.Update();
+                        EditorUtility.SetDirty(Target);
+                    }
+                }
+
+                EditorGUILayout.ObjectField(material, typeof(Material), allowSceneObjects:false);
+            }
         }
     }
 }

--- a/Editor/MaterialGroupsEditor.cs
+++ b/Editor/MaterialGroupsEditor.cs
@@ -146,8 +146,9 @@ namespace sui4.MaterialPropertyBaker
             var hasValue = Target.MaterialStatusDictDict.TryGetValue(currentRenderer, out var materialStatusDictWrapper);
             if (hasValue)
             {
+                var index = Target.MaterialStatusDictWrapperSDict.Keys.IndexOf(currentRenderer);
                 var (_, materialStatusSDictWrapperProp) =
-                    SerializedDictionaryUtil.GetKeyValueSerializedPropertyAt(ri, rendererKeysProp, matStatusSDictWrapperListProps);
+                    SerializedDictionaryUtil.GetKeyValueSerializedPropertyAt(index, rendererKeysProp, matStatusSDictWrapperListProps);
                 var (matListProp, isTargetListProp) = GetSerializedPropertyFrom(materialStatusSDictWrapperProp);
                 
                 // foreachで回すと、要素の変更時にエラーが出るので、forで回す
@@ -177,8 +178,7 @@ namespace sui4.MaterialPropertyBaker
                     EditorGUILayout.PropertyField(isTarget, Styles.IsTargetLabel);
                     if (change.changed)
                     {
-                        materialStatusDictWrapper.MaterialStatusDict[(Material)materialProp.objectReferenceValue] = isTarget.boolValue;
-                        serializedObject.Update();
+                        serializedObject.ApplyModifiedProperties();
                         EditorUtility.SetDirty(Target);
                     }
                 }

--- a/Runtime/MaterialGroups.cs
+++ b/Runtime/MaterialGroups.cs
@@ -79,10 +79,10 @@ namespace sui4.MaterialPropertyBaker
 
         public BakedMaterialProperty OverrideDefaultPreset
         {
-            get => _overrideOverrideDefaultPreset;
-            set => _overrideOverrideDefaultPreset = value;
+            get => _overrideDefaultPreset;
+            set => _overrideDefaultPreset = value;
         }
-        [SerializeField] private BakedMaterialProperty _overrideOverrideDefaultPreset;
+        [SerializeField] private BakedMaterialProperty _overrideDefaultPreset;
 
         public MaterialPropertyConfig MaterialPropertyConfig
         {

--- a/Runtime/MaterialGroups.cs
+++ b/Runtime/MaterialGroups.cs
@@ -189,9 +189,9 @@ namespace sui4.MaterialPropertyBaker
 
         public void ResetDefaultPropertyBlock()
         {
-            if (_overrideOverrideDefaultPreset)
+            if (_overrideDefaultPreset)
             {
-                SetPropertyBlock(_overrideOverrideDefaultPreset.MaterialProps);
+                SetPropertyBlock(_overrideDefaultPreset.MaterialProps);
             }
             else
             {

--- a/Runtime/MaterialGroups.cs
+++ b/Runtime/MaterialGroups.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using UnityEditor;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 namespace sui4.MaterialPropertyBaker
 {
@@ -92,6 +90,7 @@ namespace sui4.MaterialPropertyBaker
         [SerializeField] private MaterialPropertyConfig _materialPropertyConfig;
         
         public Dictionary<Renderer, MaterialStatusDictWrapper> MaterialStatusDictDict => _materialStatusDictDict.Dictionary;
+        public SerializedDictionary<Renderer, MaterialStatusDictWrapper> MaterialStatusDictWrapperSDict => _materialStatusDictDict;
         [SerializeField] private SerializedDictionary<Renderer, MaterialStatusDictWrapper> _materialStatusDictDict = new SerializedDictionary<Renderer, MaterialStatusDictWrapper>();
         
         public List<Renderer> Renderers => _renderers;

--- a/Runtime/MaterialGroups.cs
+++ b/Runtime/MaterialGroups.cs
@@ -130,12 +130,11 @@ namespace sui4.MaterialPropertyBaker
                         {
                             _mpb = new MaterialPropertyBlock();
                         }
+                        // property blockに値をセットし、rendererにproperty blockをセットする
+                        Utils.UpdatePropertyBlockFromProps(ref _mpb, materialProps);
+                        renderer.SetPropertyBlock(_mpb, mi);
                     }
-                    // property blockに値をセットし、rendererにproperty blockをセットする
-                    Utils.UpdatePropertyBlockFromProps(ref _mpb, materialProps);
-                    renderer.SetPropertyBlock(_mpb, mi);
                 }
-
             }
         }
 
@@ -159,10 +158,10 @@ namespace sui4.MaterialPropertyBaker
                         {
                             _mpb = new MaterialPropertyBlock();
                         }
+                        // property blockに値をセットし、rendererにproperty blockをセットする
+                        Utils.UpdatePropertyBlockFromDict(ref _mpb, cPropMap, fPropMap);
+                        renderer.SetPropertyBlock(_mpb, mi);
                     }
-                    // property blockに値をセットし、rendererにproperty blockをセットする
-                    Utils.UpdatePropertyBlockFromDict(ref _mpb, cPropMap, fPropMap);
-                    renderer.SetPropertyBlock(_mpb, mi);
                 }
             }
         }

--- a/Runtime/MaterialGroups.cs
+++ b/Runtime/MaterialGroups.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace sui4.MaterialPropertyBaker
 {
@@ -40,7 +42,6 @@ namespace sui4.MaterialPropertyBaker
     [Serializable]
     public class MaterialStatusList
     {
-        
         public Renderer Renderer
         {
             get => _renderer;
@@ -62,7 +63,15 @@ namespace sui4.MaterialPropertyBaker
 
         public MaterialStatusList() { }
     }
+
+    [Serializable]
+    public class MaterialStatusDictWrapper
+    {
+        public Dictionary<Material, bool> MaterialStatusDict => _materialStatusDict.Dictionary;
+        [SerializeField] private SerializedDictionary<Material, bool> _materialStatusDict = new SerializedDictionary<Material, bool>();
+    }
     
+    // [ExecuteAlways]
     public class MaterialGroups: MonoBehaviour
     {
         // レンダラーのインデックス、マテリアルのインデックス、マテリアルの状態
@@ -81,85 +90,80 @@ namespace sui4.MaterialPropertyBaker
             set => _materialPropertyConfig = value;
         }
         [SerializeField] private MaterialPropertyConfig _materialPropertyConfig;
-
-        public List<MaterialStatusList> MaterialStatusListList => _materialStatusListList;
-        [SerializeField] private List<MaterialStatusList> _materialStatusListList = new List<MaterialStatusList>();
-
+        
+        public Dictionary<Renderer, MaterialStatusDictWrapper> MaterialStatusDictDict => _materialStatusDictDict.Dictionary;
+        [SerializeField] private SerializedDictionary<Renderer, MaterialStatusDictWrapper> _materialStatusDictDict = new SerializedDictionary<Renderer, MaterialStatusDictWrapper>();
+        
+        public List<Renderer> Renderers => _renderers;
+        [SerializeField] private List<Renderer> _renderers = new List<Renderer>();
         private void OnEnable()
         {
             _mpb = new MaterialPropertyBlock();
-            if (_materialStatusListList.Count == 0)
-            {
-                _materialStatusListList.Add(new MaterialStatusList());
-            }
+            if(Renderers.Count == 0)
+                Renderers.Add(null);
+            Debug.Log($"{Renderers.Count}");
         }
 
-        public int GetIndex(int ri, int mi)
+        private void OnValidate()
         {
-            int index = 0;
-            for(int i = 0; i < ri; i++)
-            {
-                var r = _materialStatusListList[i].Renderer;
-                if(r == null) continue;
-                
-                var matNum = r.sharedMaterials.Length;
-                index += matNum;
-            }
-
-            index += mi;
-            return index;
+            if(Renderers.Count == 0)
+                Renderers.Add(null);
         }
-        
+
         public void SetPropertyBlock(in MaterialProps materialProps)
         {
             _mpb = new MaterialPropertyBlock();
-            for (int lli = 0; lli < _materialStatusListList.Count; lli++)
+            
+            foreach (var (renderer, materialStatusDictWrapper) in MaterialStatusDictDict)
             {
-                var list = _materialStatusListList[lli];
-                var ren = list.Renderer;
-                for (int li = 0; li < list.MaterialStatuses.Count; li++)
+                // PropertyBlockにはindexを用いてアクセスするので、for文で回す
+                for (int mi = 0; mi < renderer.sharedMaterials.Length; mi++)
                 {
-                    var matStatus = list.MaterialStatuses[li];
-                    if (matStatus.IsTarget)
+                    var material = renderer.sharedMaterials[mi];
+                    var hasValue = materialStatusDictWrapper.MaterialStatusDict.TryGetValue(material, out var isTarget);
+                    if (hasValue && isTarget)
                     {
                         try
                         {
-                            ren.GetPropertyBlock(_mpb, li);
+                            renderer.GetPropertyBlock(_mpb, mi);
                         }
                         catch
                         {
                             _mpb = new MaterialPropertyBlock();
                         }
-                        Utils.UpdatePropertyBlockFromProps(ref _mpb, materialProps);
-                        ren.SetPropertyBlock(_mpb, li);
                     }
+                    // property blockに値をセットし、rendererにproperty blockをセットする
+                    Utils.UpdatePropertyBlockFromProps(ref _mpb, materialProps);
+                    renderer.SetPropertyBlock(_mpb, mi);
                 }
+
             }
         }
 
         public void SetPropertyBlock(in Dictionary<int, Color> cPropMap, in Dictionary<int, float> fPropMap)
         {
             _mpb = new MaterialPropertyBlock();
-            for (int lli = 0; lli < _materialStatusListList.Count; lli++)
+            foreach (var (renderer, materialStatusDictWrapper) in MaterialStatusDictDict)
             {
-                var list = _materialStatusListList[lli];
-                var ren = list.Renderer;
-                for (int li = 0; li < list.MaterialStatuses.Count; li++)
+                // PropertyBlockにはindexを用いてアクセスするので、for文で回す
+                for (int mi = 0; mi < renderer.sharedMaterials.Length; mi++)
                 {
-                    var matStatus = list.MaterialStatuses[li];
-                    if (matStatus.IsTarget)
+                    var material = renderer.sharedMaterials[mi];
+                    var hasValue = materialStatusDictWrapper.MaterialStatusDict.TryGetValue(material, out var isTarget);
+                    if (hasValue && isTarget)
                     {
                         try
                         {
-                            ren.GetPropertyBlock(_mpb, li);
+                            renderer.GetPropertyBlock(_mpb, mi);
                         }
                         catch
                         {
                             _mpb = new MaterialPropertyBlock();
                         }
-                        Utils.UpdatePropertyBlockFromDict(ref _mpb, cPropMap, fPropMap);
-                        ren.SetPropertyBlock(_mpb, li);
                     }
+                    // property blockに値をセットし、rendererにproperty blockをセットする
+                    Utils.UpdatePropertyBlockFromDict(ref _mpb, cPropMap, fPropMap);
+                    renderer.SetPropertyBlock(_mpb, mi);
                 }
             }
         }
@@ -167,16 +171,17 @@ namespace sui4.MaterialPropertyBaker
         public void ResetPropertyBlock()
         {
             _mpb = new MaterialPropertyBlock();
-            for (int lli = 0; lli < _materialStatusListList.Count; lli++)
+            foreach (var (renderer, materialStatusDictWrapper) in MaterialStatusDictDict)
             {
-                var list = _materialStatusListList[lli];
-                var ren = list.Renderer;
-                for (int li = 0; li < list.MaterialStatuses.Count; li++)
+                // PropertyBlockにはindexを用いてアクセスするので、for文で回す
+                for (int mi = 0; mi < renderer.sharedMaterials.Length; mi++)
                 {
-                    var matStatus = list.MaterialStatuses[li];
-                    if (matStatus.IsTarget)
+                    var material = renderer.sharedMaterials[mi];
+                    var hasValue = materialStatusDictWrapper.MaterialStatusDict.TryGetValue(material, out var isTarget);
+                    if (hasValue && isTarget)
                     {
-                        ren.SetPropertyBlock(_mpb, li);
+                        // 空のproperty blockをセットするとデフォルトの値に戻る
+                        renderer.SetPropertyBlock(_mpb, mi);
                     }
                 }
             }
@@ -193,5 +198,7 @@ namespace sui4.MaterialPropertyBaker
                 ResetPropertyBlock();
             }
         }
+
+
     }
 }

--- a/Runtime/SerializedDictionary.cs
+++ b/Runtime/SerializedDictionary.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace sui4.MaterialPropertyBaker
+{
+    // Unity recorderを参考にした
+    [Serializable]
+    public class SerializedDictionary<TKey, TValue> : ISerializationCallbackReceiver
+    {
+        [SerializeField] private List<TKey> _keys = new List<TKey>();
+        [SerializeField] private List<TValue> _values = new List<TValue>();
+
+        private readonly Dictionary<TKey, TValue> _dictionary = new Dictionary<TKey, TValue>();
+
+        public Dictionary<TKey, TValue> Dictionary => _dictionary;
+
+        public void OnBeforeSerialize()
+        {
+            _keys.Clear();
+            _values.Clear();
+
+            foreach (var keyPair in _dictionary)
+            {
+                _keys.Add(keyPair.Key);
+                _values.Add(keyPair.Value);
+            }
+        }
+
+        public void OnAfterDeserialize()
+        {
+            _dictionary.Clear();
+
+            for (var i = 0; i < _keys.Count; ++i)
+                _dictionary.Add(_keys[i], _values[i]);
+        }
+    }
+}

--- a/Runtime/SerializedDictionary.cs
+++ b/Runtime/SerializedDictionary.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
 
 namespace sui4.MaterialPropertyBaker
@@ -33,6 +34,21 @@ namespace sui4.MaterialPropertyBaker
 
             for (var i = 0; i < _keys.Count; ++i)
                 _dictionary.Add(_keys[i], _values[i]);
+        }
+        
+
+    }
+
+    public class SerializedDictionaryUtil
+    {
+        public static (SerializedProperty keyListProp, SerializedProperty valueListProp) GetKeyValueListSerializedProperty(SerializedProperty serializedDictProp)
+        {
+            return (serializedDictProp.FindPropertyRelative("_keys"), serializedDictProp.FindPropertyRelative("_values"));
+        }
+        
+        public static (SerializedProperty keyProp, SerializedProperty valueProp) GetKeyValueSerializedPropertyAt(int index, SerializedProperty keyListProp, SerializedProperty valueListProp)
+        {
+            return (keyListProp.GetArrayElementAtIndex(index), valueListProp.GetArrayElementAtIndex(index));
         }
     }
 }

--- a/Runtime/SerializedDictionary.cs
+++ b/Runtime/SerializedDictionary.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using UnityEditor;
 using UnityEngine;
 
@@ -9,12 +10,19 @@ namespace sui4.MaterialPropertyBaker
     [Serializable]
     public class SerializedDictionary<TKey, TValue> : ISerializationCallbackReceiver
     {
+        public ReadOnlyCollection<TKey> Keys { get; }
         [SerializeField] private List<TKey> _keys = new List<TKey>();
+        public ReadOnlyCollection<TValue> Values { get; }
         [SerializeField] private List<TValue> _values = new List<TValue>();
 
+        public Dictionary<TKey, TValue> Dictionary => _dictionary;
         private readonly Dictionary<TKey, TValue> _dictionary = new Dictionary<TKey, TValue>();
 
-        public Dictionary<TKey, TValue> Dictionary => _dictionary;
+        public SerializedDictionary()
+        {
+            Keys = new ReadOnlyCollection<TKey>(_keys);
+            Values = new ReadOnlyCollection<TValue>(_values);
+        }
 
         public void OnBeforeSerialize()
         {
@@ -39,7 +47,7 @@ namespace sui4.MaterialPropertyBaker
 
     }
 
-    public class SerializedDictionaryUtil
+    public static class SerializedDictionaryUtil
     {
         public static (SerializedProperty keyListProp, SerializedProperty valueListProp) GetKeyValueListSerializedProperty(SerializedProperty serializedDictProp)
         {

--- a/Runtime/SerializedDictionary.cs.meta
+++ b/Runtime/SerializedDictionary.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4220d43abcfc44b1a3eb34e5efe69e0a
+timeCreated: 1691002465

--- a/Unity_MaterialPropertyBakerDemo~/Assets/Scenes/SampleScene.unity
+++ b/Unity_MaterialPropertyBakerDemo~/Assets/Scenes/SampleScene.unity
@@ -123,6 +123,11 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!23 &222782361 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 3235687531076238829, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+  m_PrefabInstance: {fileID: 2873592806562276315}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &257265408 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 95805745775101316, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
@@ -583,6 +588,16 @@ MonoBehaviour:
   _presets:
   - {fileID: 11400000, guid: 5738ae6867b59b1499458b03029edfc8, type: 2}
   - {fileID: 11400000, guid: 557b6d687686a1d4e9ff5c6ee3809aa3, type: 2}
+--- !u!23 &1110326517 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 3100110419311142613, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+  m_PrefabInstance: {fileID: 2873592806562276315}
+  m_PrefabAsset: {fileID: 0}
+--- !u!23 &1261367540 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 2512124409598779947, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+  m_PrefabInstance: {fileID: 2873592806562276315}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1370087464 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
@@ -819,22 +834,28 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _overrideOverrideDefaultPreset: {fileID: 11400000, guid: 230509335fbd71d4b9c0e0693dd9434e, type: 2}
   _materialPropertyConfig: {fileID: 11400000, guid: 6cb7daa09dee1d04aab6087987b66c05, type: 2}
-  _materialStatusListList:
-  - _renderer: {fileID: 1529053847}
-    _materialStatuses:
-    - _material: {fileID: 2100000, guid: 254341974c0acbc4b8f48f0acae1f0b4, type: 2}
-      _isTarget: 1
-      _preset: {fileID: 0}
-  - _renderer: {fileID: 2076508327}
-    _materialStatuses:
-    - _material: {fileID: 2100000, guid: 254341974c0acbc4b8f48f0acae1f0b4, type: 2}
-      _isTarget: 1
-      _preset: {fileID: 0}
-  - _renderer: {fileID: 966997200}
-    _materialStatuses:
-    - _material: {fileID: 2100000, guid: 254341974c0acbc4b8f48f0acae1f0b4, type: 2}
-      _isTarget: 1
-      _preset: {fileID: 0}
+  _materialStatusDictDict:
+    _keys:
+    - {fileID: 1529053847}
+    - {fileID: 2076508327}
+    - {fileID: 966997200}
+    _values:
+    - _materialStatusDict:
+        _keys:
+        - {fileID: 2100000, guid: 254341974c0acbc4b8f48f0acae1f0b4, type: 2}
+        _values: 01
+    - _materialStatusDict:
+        _keys:
+        - {fileID: 2100000, guid: 254341974c0acbc4b8f48f0acae1f0b4, type: 2}
+        _values: 01
+    - _materialStatusDict:
+        _keys:
+        - {fileID: 2100000, guid: 254341974c0acbc4b8f48f0acae1f0b4, type: 2}
+        _values: 01
+  _renderers:
+  - {fileID: 1529053847}
+  - {fileID: 2076508327}
+  - {fileID: 966997200}
 --- !u!1 &2076508324
 GameObject:
   m_ObjectHideFlags: 0
@@ -993,8 +1014,116 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
-      propertyPath: _materialStatusListList.Array.data[0]._materialStatuses.Array.data[0]._material
+      propertyPath: _renderers.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _renderers.Array.data[0]
       value: 
+      objectReference: {fileID: 1110326517}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _renderers.Array.data[1]
+      value: 
+      objectReference: {fileID: 222782361}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _renderers.Array.data[2]
+      value: 
+      objectReference: {fileID: 1261367540}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusListList.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusListMap._keys.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._keys.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._values.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusListMap._keys.Array.data[0]
+      value: 
+      objectReference: {fileID: 1110326517}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._keys.Array.data[0]
+      value: 
+      objectReference: {fileID: 1110326517}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._keys.Array.data[1]
+      value: 
+      objectReference: {fileID: 222782361}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._keys.Array.data[2]
+      value: 
+      objectReference: {fileID: 1261367540}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusListList.Array.data[3]._renderer
+      value: 
+      objectReference: {fileID: 1110326517}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusListList.Array.data[3]._materialStatuses.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusListList.Array.data[3]._materialStatuses.Array.data[0]._isTarget
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusListList.Array.data[3]._materialStatuses.Array.data[0]._material
+      value: 
+      objectReference: {fileID: 2100000, guid: a4d43b9db2aa12842851d24e271528ef, type: 2}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._values.Array.data[0]._materialStatusDict._keys.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._values.Array.data[1]._materialStatusDict._keys.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._values.Array.data[2]._materialStatusDict._keys.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._values.Array.data[0]._materialStatusDict._values.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._values.Array.data[1]._materialStatusDict._values.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._values.Array.data[2]._materialStatusDict._values.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._values.Array.data[0]._materialStatusDict._keys.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: a4d43b9db2aa12842851d24e271528ef, type: 2}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._values.Array.data[1]._materialStatusDict._keys.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: a4d43b9db2aa12842851d24e271528ef, type: 2}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._values.Array.data[2]._materialStatusDict._keys.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: a4d43b9db2aa12842851d24e271528ef, type: 2}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._values.Array.data[0]._materialStatusDict._values.Array.data[0]
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._values.Array.data[1]._materialStatusDict._values.Array.data[0]
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3045152378166969900, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
+      propertyPath: _materialStatusDictDict._values.Array.data[2]._materialStatusDict._values.Array.data[0]
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7887153678846179397, guid: c929b32ed7254b74fb6663ab2824c4bd, type: 3}
       propertyPath: m_Name


### PR DESCRIPTION
Issue #9 ターゲットのレンダラに更新があった際、それを反映させる
のための準備。
RendererとRendererがもつMaterialのリスト、及びMaterialごとに、それが対象かのフラグデータ（MaterialStatus）を、
Serialieの都合で、ClassとListで実装していた。
しかし、重複の検出や、PropertyBlockの適用時に適切な対応を取ること、レンダラの持つマテリアルの数が変わった際の更新などを行うには、Listでは難しかった。
よって、UnityRecorderを参考にSerializedDictionaryを実装し、それを用いるようにした。


## InspectorGUIでの工夫
Unityの仕様として、SerializedPropertyを用いてフィールドを描画すると、Prefabの値に更新があった際にそれを青く可視化してくれる上、右クリックでその値だけApply, Revertができる。
これを活用するためにSerialiedDictionaryのSerialized ListのPropertyを用いている。
しかし、OnBeforeSerialize, OnAfterDeserializeなどでDictionaryとListの変換を取ってる都合、直接いじらないほうがいい気がしたので、Dictionary経由で値を更新するようにしている。
（なおこれは不要な対応かもしれない）