### PR TITLE
MaterialGroupListからプリセットを生成できるように + Texture対応

### DIFF
--- a/Editor/BakedMaterialPropertiesEditor.cs
+++ b/Editor/BakedMaterialPropertiesEditor.cs
@@ -13,6 +13,7 @@ namespace sui4.MaterialPropertyBaker
         private SerializedProperty _materialProps;
         private SerializedProperty _colors;
         private SerializedProperty _floats;
+        private SerializedProperty _textures;
 
 
         private MaterialPropertyConfig _materialPropertyConfig;
@@ -31,6 +32,7 @@ namespace sui4.MaterialPropertyBaker
             _materialProps = serializedObject.FindProperty("_materialProps");
             _colors = _materialProps.FindPropertyRelative("_colors");
             _floats = _materialProps.FindPropertyRelative("_floats");
+            _textures = _materialProps.FindPropertyRelative("_textures");
         }
 
         public override void OnInspectorGUI()
@@ -54,6 +56,14 @@ namespace sui4.MaterialPropertyBaker
                     EditorGUILayout.LabelField("Floats", EditorStyles.boldLabel);
                     EditorGUI.indentLevel++;
                     PropsGUI(_floats, ShaderPropertyType.Float);
+                    EditorGUI.indentLevel--;
+                }
+                
+                using (new EditorGUILayout.VerticalScope("box"))
+                {
+                    EditorGUILayout.LabelField("Textures", EditorStyles.boldLabel);
+                    EditorGUI.indentLevel++;
+                    PropsGUI(_textures, ShaderPropertyType.Texture);
                     EditorGUI.indentLevel--;
                 }
 

--- a/Editor/BakedMaterialPropertiesEditor.cs
+++ b/Editor/BakedMaterialPropertiesEditor.cs
@@ -104,15 +104,14 @@ namespace sui4.MaterialPropertyBaker
                         EditorGUILayout.PropertyField(_value, new GUIContent(label));
                     }
 
-                    // remove button
-                    var tmp = GUI.backgroundColor;
-                    GUI.backgroundColor = Color.red;
-                    if (GUILayout.Button("-", GUILayout.Width(30)))
-                    {
-                        props.DeleteArrayElementAtIndex(pi);
-                    }
-
-                    GUI.backgroundColor = tmp;
+                    // // remove button
+                    // var tmp = GUI.backgroundColor;
+                    // GUI.backgroundColor = Color.red;
+                    // if (GUILayout.Button("-", GUILayout.Width(30)))
+                    // {
+                    //     props.DeleteArrayElementAtIndex(pi);
+                    // }
+                    // GUI.backgroundColor = tmp;
                 }
             }
 

--- a/Editor/BakedMaterialPropertiesEditor.cs
+++ b/Editor/BakedMaterialPropertiesEditor.cs
@@ -58,7 +58,7 @@ namespace sui4.MaterialPropertyBaker
                     PropsGUI(_floats, ShaderPropertyType.Float);
                     EditorGUI.indentLevel--;
                 }
-                
+
                 using (new EditorGUILayout.VerticalScope("box"))
                 {
                     EditorGUILayout.LabelField("Textures", EditorStyles.boldLabel);

--- a/Editor/BakedMaterialPropertiesEditor.cs
+++ b/Editor/BakedMaterialPropertiesEditor.cs
@@ -40,7 +40,6 @@ namespace sui4.MaterialPropertyBaker
             using (var change = new EditorGUI.ChangeCheckScope())
             {
                 EditorGUILayout.LabelField("Shader", _shaderName.stringValue, EditorStyles.boldLabel);
-                EditorGUILayout.Separator();
 
                 using (new EditorGUILayout.VerticalScope("box"))
                 {
@@ -50,7 +49,6 @@ namespace sui4.MaterialPropertyBaker
                     EditorGUI.indentLevel--;
                 }
 
-                EditorGUILayout.Separator();
                 using (new EditorGUILayout.VerticalScope("box"))
                 {
                     EditorGUILayout.LabelField("Floats", EditorStyles.boldLabel);

--- a/Editor/BakedPropertyGroupEditor.cs
+++ b/Editor/BakedPropertyGroupEditor.cs
@@ -16,6 +16,7 @@ namespace sui4.MaterialPropertyBaker
         private List<bool> _foldouts = new List<bool>();
 
         private List<BakedMaterialPropertiesEditor> _bakedPropertyEditors = new List<BakedMaterialPropertiesEditor>();
+
         private void OnEnable()
         {
             _presetIDPairsProp = serializedObject.FindProperty("_presetIDPairs");
@@ -31,12 +32,12 @@ namespace sui4.MaterialPropertyBaker
             SessionState.SetBool("foldout" + index, state);
             _foldouts[index] = state;
         }
-        
+
         public override void OnInspectorGUI()
         {
             // base.OnInspectorGUI();
-            if(Target == null) return;
-            
+            if (Target == null) return;
+
             serializedObject.Update();
             using (var change = new EditorGUI.ChangeCheckScope())
             {
@@ -65,21 +66,22 @@ namespace sui4.MaterialPropertyBaker
                     _foldouts[pi] = tmp;
                     SaveFoldoutState(pi, _foldouts[pi]);
                 }
+
                 if (!_foldouts[pi]) continue;
-                
+
                 using (new EditorGUI.IndentLevelScope())
                 {
                     EditorGUILayout.PropertyField(idProp);
                     EditorGUILayout.PropertyField(presetProp);
-                
+
                     var preset = presetProp.objectReferenceValue as BakedMaterialProperty;
                     using (new EditorGUILayout.VerticalScope("box"))
                     {
                         BakedPropertyEditorGUI(preset, pi);
                     }
                 }
-
             }
+
             EditorGUI.indentLevel--;
         }
 
@@ -89,7 +91,7 @@ namespace sui4.MaterialPropertyBaker
             {
                 return;
             }
-            
+
             if (_bakedPropertyEditors[index] == null)
             {
                 _bakedPropertyEditors[index] = (BakedMaterialPropertiesEditor)CreateEditor(bakedProperty);
@@ -107,7 +109,6 @@ namespace sui4.MaterialPropertyBaker
                 EditorGUI.indentLevel++;
                 _bakedPropertyEditors[index].OnInspectorGUI();
                 EditorGUI.indentLevel--;
-
             }
         }
 

--- a/Editor/BakedPropertyGroupEditor.cs
+++ b/Editor/BakedPropertyGroupEditor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEditor;
+using UnityEditorInternal;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -9,17 +10,105 @@ namespace sui4.MaterialPropertyBaker
     [CustomEditor(typeof(BakedPropertyGroup))]
     public class BakedPropertyGroupEditor : Editor
     {
+        private SerializedProperty _presetIDPairsProp;
         private BakedPropertyGroup Target => (BakedPropertyGroup)target;
         private List<string> _warnings = new List<string>();
+        private List<bool> _foldouts = new List<bool>();
 
+        private List<BakedMaterialPropertiesEditor> _bakedPropertyEditors = new List<BakedMaterialPropertiesEditor>();
+        private void OnEnable()
+        {
+            _presetIDPairsProp = serializedObject.FindProperty("_presetIDPairs");
+            for (int pi = 0; pi < _presetIDPairsProp.arraySize; pi++)
+            {
+                _bakedPropertyEditors.Add(null);
+                _foldouts.Add(SessionState.GetBool("foldout" + pi, true));
+            }
+        }
+
+        private void SaveFoldoutState(int index, bool state)
+        {
+            SessionState.SetBool("foldout" + index, state);
+            _foldouts[index] = state;
+        }
+        
         public override void OnInspectorGUI()
         {
-            base.OnInspectorGUI();
+            // base.OnInspectorGUI();
+            if(Target == null) return;
+            
+            serializedObject.Update();
+            using (var change = new EditorGUI.ChangeCheckScope())
+            {
+                PairsGUI();
+                if (change.changed)
+                {
+                    serializedObject.ApplyModifiedProperties();
+                }
+            }
+
             WarningGUI(Target.Warnings);
         }
 
-        private void PairGUI()
+        private void PairsGUI()
         {
+            EditorGUILayout.LabelField("Preset ID Pairs", EditorStyles.boldLabel);
+            EditorGUI.indentLevel++;
+            for (var pi = 0; pi < _presetIDPairsProp.arraySize; pi++)
+            {
+                var pairProp = _presetIDPairsProp.GetArrayElementAtIndex(pi);
+                var presetProp = pairProp.FindPropertyRelative("_preset");
+                var idProp = pairProp.FindPropertyRelative("_id");
+                var tmp = EditorGUILayout.Foldout(_foldouts[pi], idProp.stringValue);
+                if (tmp != _foldouts[pi])
+                {
+                    _foldouts[pi] = tmp;
+                    SaveFoldoutState(pi, _foldouts[pi]);
+                }
+                if (!_foldouts[pi]) continue;
+                
+                using (new EditorGUI.IndentLevelScope())
+                {
+                    EditorGUILayout.PropertyField(idProp);
+                    EditorGUILayout.PropertyField(presetProp);
+                
+                    var preset = presetProp.objectReferenceValue as BakedMaterialProperty;
+                    using (new EditorGUILayout.VerticalScope("box"))
+                    {
+                        BakedPropertyEditorGUI(preset, pi);
+                    }
+                }
+
+            }
+            EditorGUI.indentLevel--;
+        }
+
+        private void BakedPropertyEditorGUI(BakedMaterialProperty bakedProperty, int index)
+        {
+            if (index >= _bakedPropertyEditors.Count || index < 0 || bakedProperty == null)
+            {
+                return;
+            }
+            
+            if (_bakedPropertyEditors[index] == null)
+            {
+                _bakedPropertyEditors[index] = (BakedMaterialPropertiesEditor)CreateEditor(bakedProperty);
+            }
+            else if (_bakedPropertyEditors[index].target != bakedProperty)
+            {
+                DestroyImmediate(_bakedPropertyEditors[index]);
+                _bakedPropertyEditors[index] = null;
+                _bakedPropertyEditors[index] = (BakedMaterialPropertiesEditor)CreateEditor(bakedProperty);
+            }
+
+            if (_bakedPropertyEditors[index] != null)
+            {
+                EditorGUILayout.LabelField($"{bakedProperty.name}", EditorStyles.boldLabel);
+                EditorGUI.indentLevel++;
+                _bakedPropertyEditors[index].OnInspectorGUI();
+                EditorGUI.indentLevel--;
+
+            }
         }
 
         private void WarningGUI(List<string> warnings)

--- a/Editor/MaterialGroupEditor.cs
+++ b/Editor/MaterialGroupEditor.cs
@@ -94,6 +94,7 @@ namespace sui4.MaterialPropertyBaker
                     }
                 }
             }
+
             WarningGUI(Target.Warnings);
         }
 
@@ -240,6 +241,7 @@ namespace sui4.MaterialPropertyBaker
                 }
             }
         }
+
         private void WarningGUI(List<string> warnings)
         {
             // helpBox
@@ -251,6 +253,7 @@ namespace sui4.MaterialPropertyBaker
                 }
             }
         }
+
         // utils
         private static (SerializedProperty keyMaterialListProp, SerializedProperty valueIsTargetListProp)
             GetSerializedPropertyFrom(SerializedProperty materialStatusSDictWrapperProp)

--- a/Editor/MaterialGroupEditor.cs
+++ b/Editor/MaterialGroupEditor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
@@ -93,6 +94,7 @@ namespace sui4.MaterialPropertyBaker
                     }
                 }
             }
+            WarningGUI(Target.Warnings);
         }
 
         // ri = renderer index
@@ -238,7 +240,17 @@ namespace sui4.MaterialPropertyBaker
                 }
             }
         }
-
+        private void WarningGUI(List<string> warnings)
+        {
+            // helpBox
+            if (warnings.Count > 0)
+            {
+                foreach (var warning in warnings)
+                {
+                    EditorGUILayout.HelpBox(warning, MessageType.Warning);
+                }
+            }
+        }
         // utils
         private static (SerializedProperty keyMaterialListProp, SerializedProperty valueIsTargetListProp)
             GetSerializedPropertyFrom(SerializedProperty materialStatusSDictWrapperProp)

--- a/Editor/MaterialPropertyExporter.cs
+++ b/Editor/MaterialPropertyExporter.cs
@@ -20,7 +20,7 @@ namespace sui4.MaterialPropertyBaker
 
         private BakedMaterialProperty _bakedMaterialProperty;
 
-        [MenuItem("tools/Material Property Baker/Material Property Exporter")]
+        [MenuItem("MaterialPropertyBaker/Material Property Exporter")]
         public static void Init()
         {
             var window = (MaterialPropertyExporter)GetWindow(typeof(MaterialPropertyExporter));

--- a/Editor/MaterialPropertyExporter.cs
+++ b/Editor/MaterialPropertyExporter.cs
@@ -56,7 +56,7 @@ namespace sui4.MaterialPropertyBaker
                     }
                     else
                     {
-                        DestryAssets();
+                        DestroyAssets();
                     }
                 }
             }
@@ -177,7 +177,7 @@ namespace sui4.MaterialPropertyBaker
             GenerateBakedMaterialProperty(_targetMaterial);
         }
 
-        private void DestryAssets()
+        private void DestroyAssets()
         {
             DestroyConfigIfExist();
             DestroyBakedMaterialPropertyIfExist();

--- a/Editor/MaterialPropsPropertyDrawer.cs
+++ b/Editor/MaterialPropsPropertyDrawer.cs
@@ -8,6 +8,7 @@ namespace sui4.MaterialPropertyBaker
     {
         private SerializedProperty _colors;
         private SerializedProperty _floats;
+        private SerializedProperty _textures;
 
         private SerializedProperty _property;
         private SerializedProperty _value;
@@ -18,6 +19,7 @@ namespace sui4.MaterialPropertyBaker
 
             _colors = property.FindPropertyRelative("_colors");
             _floats = property.FindPropertyRelative("_floats");
+            _textures = property.FindPropertyRelative("_textures");
 
             // Colors
             EditorGUILayout.LabelField("Colors", EditorStyles.boldLabel);
@@ -25,11 +27,19 @@ namespace sui4.MaterialPropertyBaker
             PropsGUI(_colors, true);
             EditorGUI.indentLevel--;
 
-            // Floats
             EditorGUILayout.Space();
+            // Floats
             EditorGUILayout.LabelField("Floats", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
             PropsGUI(_floats);
+            EditorGUI.indentLevel--;
+
+            EditorGUILayout.Space();
+            // Textures
+            EditorGUILayout.LabelField("Textures", EditorStyles.boldLabel);
+            EditorGUI.indentLevel++;
+            PropsGUI(_textures);
+            EditorGUI.indentLevel--;
 
             EditorGUI.EndProperty();
         }

--- a/Editor/PropertiesBakerWidnow.cs
+++ b/Editor/PropertiesBakerWidnow.cs
@@ -8,7 +8,8 @@ using UnityEngine;
 
 namespace sui4.MaterialPropertyBaker
 {
-    [EditorWindowTitle(title = "Material Property Baker")]
+    // old version: not used
+    [EditorWindowTitle(title = "Material Property Baker (Old)")]
     public class MaterialPropsExporter : EditorWindow
     {
         [SerializeField] private List<Material> _targets = new List<Material>();

--- a/Runtime/BakedMaterialProperty.cs
+++ b/Runtime/BakedMaterialProperty.cs
@@ -46,7 +46,8 @@ namespace sui4.MaterialPropertyBaker
             _materialProps.CopyValuesFromOther(matProps);
         }
 
-        public void GetCopyProperties(out List<MaterialProp<Color>> cList, out List<MaterialProp<float>> fList, out List<MaterialProp<Texture>> tList)
+        public void GetCopyProperties(out List<MaterialProp<Color>> cList, out List<MaterialProp<float>> fList,
+            out List<MaterialProp<Texture>> tList)
         {
             MaterialProps.GetCopyProperties(out cList, out fList, out tList);
         }
@@ -63,33 +64,44 @@ namespace sui4.MaterialPropertyBaker
         {
             if (config == null) return;
 
-            var colorDeleteIndex = new List<int>();
-            var floatDeleteIndex = new List<int>();
-
+            var colorToDelete = new List<MaterialProp<Color>>();
+            var floatToDelete = new List<MaterialProp<float>>();
+            var textureToDelete = new List<MaterialProp<Texture>>();
             // 含まれないプロパティを探す
-            for (var ci = 0; ci < _materialProps.Colors.Count; ci++)
+            foreach (var colorProp in _materialProps.Colors)
             {
-                var colorProp = _materialProps.Colors[ci];
                 var index = config.PropertyNames.IndexOf(colorProp.Name);
                 if (index == -1)
-                    colorDeleteIndex.Add(ci);
-                else if (config.Editable[index] == false) colorDeleteIndex.Add(ci);
+                    colorToDelete.Add(colorProp);
+                else if (config.Editable[index] == false)
+                    colorToDelete.Add(colorProp);
             }
 
-            for (var fi = 0; fi < _materialProps.Floats.Count; fi++)
+            foreach (var floatProp in _materialProps.Floats)
             {
-                var floatProp = _materialProps.Floats[fi];
                 var index = config.PropertyNames.IndexOf(floatProp.Name);
                 if (index == -1)
-                    floatDeleteIndex.Add(fi);
-                else if (config.Editable[index] == false) floatDeleteIndex.Add(fi);
+                    floatToDelete.Add(floatProp);
+                else if (config.Editable[index] == false)
+                    floatToDelete.Add(floatProp);
             }
 
-            // 後ろから削除
-            for (var di = colorDeleteIndex.Count - 1; di >= 0; di--)
-                _materialProps.Colors.RemoveAt(colorDeleteIndex[di]);
-            for (var di = floatDeleteIndex.Count - 1; di >= 0; di--)
-                _materialProps.Floats.RemoveAt(floatDeleteIndex[di]);
+            foreach (var textureProp in _materialProps.Textures)
+            {
+                var index = config.PropertyNames.IndexOf(textureProp.Name);
+                if (index == -1)
+                    textureToDelete.Add(textureProp);
+                else if (config.Editable[index] == false)
+                    textureToDelete.Add(textureProp);
+            }
+
+            // 該当プロパティを削除
+            foreach (var c in colorToDelete)
+                _materialProps.Colors.Remove(c);
+            foreach (var f in floatToDelete)
+                _materialProps.Floats.Remove(f);
+            foreach (var t in textureToDelete)
+                _materialProps.Textures.Remove(t);
         }
     }
 }

--- a/Runtime/BakedMaterialProperty.cs
+++ b/Runtime/BakedMaterialProperty.cs
@@ -30,32 +30,13 @@ namespace sui4.MaterialPropertyBaker
         public void UpdateShaderID()
         {
             if (_materialProps != null)
-                _materialProps.UpdateShaderID();
+                _materialProps.UpdateShaderIDs();
         }
 
         public void CreatePropsFromMaterial(in Material mat)
         {
             _shaderName = mat.shader.name;
-            var colors = new List<MaterialProp<Color>>();
-            var floats = new List<MaterialProp<float>>();
-            for (var pi = 0; pi < mat.shader.GetPropertyCount(); pi++)
-            {
-                var propType = mat.shader.GetPropertyType(pi);
-                var propName = mat.shader.GetPropertyName(pi);
-
-                switch (propType)
-                {
-                    case ShaderPropertyType.Color:
-                        colors.Add(new MaterialProp<Color>(propName, mat));
-                        break;
-                    case ShaderPropertyType.Float:
-                    case ShaderPropertyType.Range:
-                        floats.Add(new MaterialProp<float>(propName, mat));
-                        break;
-                }
-            }
-
-            _materialProps = new MaterialProps(colors, floats);
+            _materialProps = new MaterialProps(mat);
             UpdateShaderID();
         }
 
@@ -65,9 +46,9 @@ namespace sui4.MaterialPropertyBaker
             _materialProps.CopyValuesFromOther(matProps);
         }
 
-        public void GetCopyProperties(out List<MaterialProp<Color>> cList, out List<MaterialProp<float>> fList)
+        public void GetCopyProperties(out List<MaterialProp<Color>> cList, out List<MaterialProp<float>> fList, out List<MaterialProp<Texture>> tList)
         {
-            MaterialProps.GetCopyProperties(out cList, out fList);
+            MaterialProps.GetCopyProperties(out cList, out fList, out tList);
         }
 
         public void CopyValuesFromOther(in BakedMaterialProperty other)

--- a/Runtime/BakedPropertyGroup.cs
+++ b/Runtime/BakedPropertyGroup.cs
@@ -14,8 +14,8 @@ namespace sui4.MaterialPropertyBaker
 
         public PresetIDPair()
         {
-            
         }
+
         public PresetIDPair(string id, BakedMaterialProperty preset)
         {
             _id = id;

--- a/Runtime/BakedPropertyGroup.cs
+++ b/Runtime/BakedPropertyGroup.cs
@@ -11,6 +11,16 @@ namespace sui4.MaterialPropertyBaker
         [SerializeField] private BakedMaterialProperty _preset;
         public string ID => _id;
         public BakedMaterialProperty Preset => _preset;
+
+        public PresetIDPair()
+        {
+            
+        }
+        public PresetIDPair(string id, BakedMaterialProperty preset)
+        {
+            _id = id;
+            _preset = preset;
+        }
     }
 
     [CreateAssetMenu(menuName = "MaterialPropertyBaker/BakedPropertyGroup", order = 1)]

--- a/Runtime/MateiralProps.cs
+++ b/Runtime/MateiralProps.cs
@@ -35,14 +35,17 @@ namespace sui4.MaterialPropertyBaker
                 switch (propType)
                 {
                     case ShaderPropertyType.Color:
-                        Colors.Add(new MaterialProp<Color>(propName, mat));
+                        var colorValue = mat.GetColor(propName);
+                        Colors.Add(new MaterialProp<Color>(propName, colorValue));
                         break;
                     case ShaderPropertyType.Float:
                     case ShaderPropertyType.Range:
-                        Floats.Add(new MaterialProp<float>(propName, mat));
+                        var floatValue = mat.GetFloat(propName);
+                        Floats.Add(new MaterialProp<float>(propName, floatValue));
                         break;
                     case ShaderPropertyType.Texture:
-                        Textures.Add(new MaterialProp<Texture>(propName, mat));
+                        var texValue = mat.GetTexture(propName);
+                        Textures.Add(new MaterialProp<Texture>(propName, texValue));
                         break;
                     case ShaderPropertyType.Int:
                     case ShaderPropertyType.Vector:
@@ -214,17 +217,17 @@ namespace sui4.MaterialPropertyBaker
             Value = value;
         }
 
-        public MaterialProp(string propName, Material mat) : this(propName)
-        {
-            Value = typeof(T) switch
-            {
-                { } t when t == typeof(Color) => (T)Convert.ChangeType(mat.GetColor(ID), typeof(T)),
-                { } t when t == typeof(Vector4) => (T)Convert.ChangeType(mat.GetVector(ID), typeof(T)),
-                { } t when t == typeof(float) => (T)Convert.ChangeType(mat.GetFloat(ID), typeof(T)),
-                { } t when t == typeof(Texture) => (T)Convert.ChangeType(mat.GetTexture(ID), typeof(T)),
-                _ => Value
-            };
-        }
+        // public MaterialProp(string propName, Material mat) : this(propName)
+        // {
+        //     Value = typeof(T) switch
+        //     {
+        //         { } t when t == typeof(Color) => (T)Convert.ChangeType(mat.GetColor(ID), typeof(T)),
+        //         { } t when t == typeof(Vector4) => (T)Convert.ChangeType(mat.GetVector(ID), typeof(T)),
+        //         { } t when t == typeof(float) => (T)Convert.ChangeType(mat.GetFloat(ID), typeof(T)),
+        //         { } t when t == typeof(Texture) => (T)Convert.ChangeType(mat.GetTexture(ID), typeof(T)), // textureはIConvertibleじゃないので、Convert.ChangeTypeできない
+        //         _ => Value
+        //     };
+        // }
 
         public string Name
         {

--- a/Runtime/MateiralProps.cs
+++ b/Runtime/MateiralProps.cs
@@ -143,7 +143,8 @@ namespace sui4.MaterialPropertyBaker
             return hasProp;
         }
 
-        public void GetCopyProperties(out List<MaterialProp<Color>> cList, out List<MaterialProp<float>> fList, out List<MaterialProp<Texture>> tList)
+        public void GetCopyProperties(out List<MaterialProp<Color>> cList, out List<MaterialProp<float>> fList,
+            out List<MaterialProp<Texture>> tList)
         {
             cList = new List<MaterialProp<Color>>();
             fList = new List<MaterialProp<float>>();

--- a/Runtime/MaterialGroup.cs
+++ b/Runtime/MaterialGroup.cs
@@ -181,7 +181,7 @@ namespace sui4.MaterialPropertyBaker
                 }
         }
 
-        public void SetPropertyBlock(in Dictionary<int, Color> cPropMap, in Dictionary<int, float> fPropMap)
+        public void SetPropertyBlock(in Dictionary<int, Color> cPropMap, in Dictionary<int, float> fPropMap, in Dictionary<int, Texture> tPropMap)
         {
             _mpb = new MaterialPropertyBlock();
             foreach (var (renderer, materialStatusDictWrapper) in MaterialStatusDictDict)
@@ -202,7 +202,7 @@ namespace sui4.MaterialPropertyBaker
                         }
 
                         // property blockに値をセットし、rendererにproperty blockをセットする
-                        Utils.UpdatePropertyBlockFromDict(ref _mpb, cPropMap, fPropMap);
+                        Utils.UpdatePropertyBlockFromDict(ref _mpb, cPropMap, fPropMap, tPropMap);
                         renderer.SetPropertyBlock(_mpb, mi);
                     }
                 }

--- a/Runtime/MaterialGroup.cs
+++ b/Runtime/MaterialGroup.cs
@@ -126,6 +126,33 @@ namespace sui4.MaterialPropertyBaker
             }
         }
 
+        // shaderがconfigと違う場合はisTargetをfalseにする
+        [ContextMenu("Disable UnMatch Material")]
+        private void UnTargetUnMatchMaterial()
+        {
+            if(MaterialPropertyConfig == null) return;
+
+            var shaderName = MaterialPropertyConfig.ShaderName;
+            
+            foreach (var (_, materialStatusDictWrapper) in MaterialStatusDictDict)
+            {
+                List<Material> materialsToDisable = new();
+                foreach (var (material, isTarget) in materialStatusDictWrapper.MaterialStatusDict)
+                {
+                    if (isTarget && material.shader.name != shaderName)
+                    {
+                        materialsToDisable.Add(material);
+                    }
+                }
+
+                foreach (var mat in materialsToDisable)
+                {
+                    materialStatusDictWrapper.MaterialStatusDict[mat] = false;
+                }
+            }
+            OnValidate();
+        }
+
         public void SetPropertyBlock(in MaterialProps materialProps)
         {
             _mpb = new MaterialPropertyBlock();

--- a/Runtime/MaterialGroup.cs
+++ b/Runtime/MaterialGroup.cs
@@ -24,6 +24,7 @@ namespace sui4.MaterialPropertyBaker
 
         // レンダラーのインデックス、マテリアルのインデックス、マテリアルの状態
         private MaterialPropertyBlock _mpb;
+        private List<string> _warnings = new();
 
         public BakedMaterialProperty OverrideDefaultPreset
         {
@@ -44,6 +45,7 @@ namespace sui4.MaterialPropertyBaker
             _materialStatusDictDict;
 
         public List<Renderer> Renderers => _renderers;
+        public List<string> Warnings => _warnings;
 
         public string ID
         {
@@ -60,6 +62,8 @@ namespace sui4.MaterialPropertyBaker
 
         public void OnValidate()
         {
+            _warnings.Clear();
+            
             if (string.IsNullOrWhiteSpace(ID))
             {
                 ID = "Group_" + Guid.NewGuid().ToString();
@@ -67,6 +71,13 @@ namespace sui4.MaterialPropertyBaker
 
             if (Renderers.Count == 0)
                 Renderers.Add(null);
+            
+            SyncMaterial();
+            ValidateShaderName();
+        }
+
+        private void SyncMaterial()
+        {
             foreach (var renderer in Renderers)
             {
                 if (renderer == null)
@@ -82,9 +93,35 @@ namespace sui4.MaterialPropertyBaker
                         if (!Array.Exists(renderer.sharedMaterials, m => m == material))
                             materialKeysToRemove.Add(material);
                     foreach (var mat in materialKeysToRemove) materialStatusDictWrapper.MaterialStatusDict.Remove(mat);
-                    // materialが増えてれば追加する
+                    // materialが増えてれば追加する. shaderが違う場合はisTargetをfalseにする
                     foreach (var material in renderer.sharedMaterials)
-                        materialStatusDictWrapper.MaterialStatusDict.TryAdd(material, true);
+                    {
+                        if (MaterialPropertyConfig != null && material.shader.name != MaterialPropertyConfig.ShaderName)
+                        {
+                            materialStatusDictWrapper.MaterialStatusDict.TryAdd(material, false);
+                        }
+                        else
+                        {
+                            materialStatusDictWrapper.MaterialStatusDict.TryAdd(material, true);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void ValidateShaderName()
+        {
+            if(MaterialPropertyConfig == null) return;
+
+            var shaderName = MaterialPropertyConfig.ShaderName;
+            foreach (var (renderer, materialStatusDictWrapper) in MaterialStatusDictDict)
+            {
+                foreach (var (material, isTarget) in materialStatusDictWrapper.MaterialStatusDict)
+                {
+                    if (isTarget && material.shader.name != shaderName)
+                    {
+                        _warnings.Add($"Material({material.name}) of Renderer({renderer.name}) use different shader from config({shaderName})");
+                    }
                 }
             }
         }

--- a/Runtime/MaterialGroup.cs
+++ b/Runtime/MaterialGroup.cs
@@ -63,7 +63,7 @@ namespace sui4.MaterialPropertyBaker
         public void OnValidate()
         {
             _warnings.Clear();
-            
+
             if (string.IsNullOrWhiteSpace(ID))
             {
                 ID = "Group_" + Guid.NewGuid().ToString();
@@ -71,7 +71,7 @@ namespace sui4.MaterialPropertyBaker
 
             if (Renderers.Count == 0)
                 Renderers.Add(null);
-            
+
             SyncMaterial();
             ValidateShaderName();
         }
@@ -111,7 +111,7 @@ namespace sui4.MaterialPropertyBaker
 
         private void ValidateShaderName()
         {
-            if(MaterialPropertyConfig == null) return;
+            if (MaterialPropertyConfig == null) return;
 
             var shaderName = MaterialPropertyConfig.ShaderName;
             foreach (var (renderer, materialStatusDictWrapper) in MaterialStatusDictDict)
@@ -120,7 +120,8 @@ namespace sui4.MaterialPropertyBaker
                 {
                     if (isTarget && material.shader.name != shaderName)
                     {
-                        _warnings.Add($"Material({material.name}) of Renderer({renderer.name}) use different shader from config({shaderName})");
+                        _warnings.Add(
+                            $"Material({material.name}) of Renderer({renderer.name}) use different shader from config({shaderName})");
                     }
                 }
             }
@@ -130,10 +131,10 @@ namespace sui4.MaterialPropertyBaker
         [ContextMenu("Disable UnMatch Material")]
         private void UnTargetUnMatchMaterial()
         {
-            if(MaterialPropertyConfig == null) return;
+            if (MaterialPropertyConfig == null) return;
 
             var shaderName = MaterialPropertyConfig.ShaderName;
-            
+
             foreach (var (_, materialStatusDictWrapper) in MaterialStatusDictDict)
             {
                 List<Material> materialsToDisable = new();
@@ -150,6 +151,7 @@ namespace sui4.MaterialPropertyBaker
                     materialStatusDictWrapper.MaterialStatusDict[mat] = false;
                 }
             }
+
             OnValidate();
         }
 
@@ -181,7 +183,8 @@ namespace sui4.MaterialPropertyBaker
                 }
         }
 
-        public void SetPropertyBlock(in Dictionary<int, Color> cPropMap, in Dictionary<int, float> fPropMap, in Dictionary<int, Texture> tPropMap)
+        public void SetPropertyBlock(in Dictionary<int, Color> cPropMap, in Dictionary<int, float> fPropMap,
+            in Dictionary<int, Texture> tPropMap)
         {
             _mpb = new MaterialPropertyBlock();
             foreach (var (renderer, materialStatusDictWrapper) in MaterialStatusDictDict)

--- a/Runtime/MaterialGroupList.cs
+++ b/Runtime/MaterialGroupList.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
 
 namespace sui4.MaterialPropertyBaker
@@ -57,5 +58,28 @@ namespace sui4.MaterialPropertyBaker
                 FindObjectsSortMode.None);
             _materialGroupsInScene = new List<MaterialGroup>(materialGroups);
         }
+        
+#if UNITY_EDITOR
+        [ContextMenu("Create Baked Property Group Asset")]
+        private void CreateBakedPropertyGroupAsset()
+        {
+            var propertyGroup = ScriptableObject.CreateInstance<BakedPropertyGroup>();
+            foreach (var mg in MaterialGroups)
+            {
+                var presetIDPairs = new PresetIDPair(mg.ID, null);
+                propertyGroup.PresetIDPairs.Add(presetIDPairs);
+            }
+            var defaultName = $"New BakedPropertyGroup";
+            var path = EditorUtility.SaveFilePanelInProject("Create BakedPropertyGroup", defaultName, "asset",
+                "BakedPropertyGroup");
+            if (string.IsNullOrEmpty(path))
+            {
+                Debug.LogError("Failed to Create BakedPropertyGroup: Invalid Path");
+                return;
+            }
+            AssetDatabase.CreateAsset(propertyGroup, path);
+            AssetDatabase.SaveAssets();
+        }
+#endif
     }
 }

--- a/Runtime/MaterialGroupList.cs
+++ b/Runtime/MaterialGroupList.cs
@@ -58,7 +58,7 @@ namespace sui4.MaterialPropertyBaker
                 FindObjectsSortMode.None);
             _materialGroupsInScene = new List<MaterialGroup>(materialGroups);
         }
-        
+
 #if UNITY_EDITOR
         [ContextMenu("Create Baked Property Group Asset")]
         private void CreateBakedPropertyGroupAsset()
@@ -69,6 +69,7 @@ namespace sui4.MaterialPropertyBaker
                 var presetIDPairs = new PresetIDPair(mg.ID, null);
                 propertyGroup.PresetIDPairs.Add(presetIDPairs);
             }
+
             var defaultName = $"New BakedPropertyGroup";
             var path = EditorUtility.SaveFilePanelInProject("Create BakedPropertyGroup", defaultName, "asset",
                 "BakedPropertyGroup");
@@ -77,6 +78,7 @@ namespace sui4.MaterialPropertyBaker
                 Debug.LogError("Failed to Create BakedPropertyGroup: Invalid Path");
                 return;
             }
+
             AssetDatabase.CreateAsset(propertyGroup, path);
             AssetDatabase.SaveAssets();
         }

--- a/Runtime/Timline/MaterialPropSwitcherMixerBehaviour.cs
+++ b/Runtime/Timline/MaterialPropSwitcherMixerBehaviour.cs
@@ -82,7 +82,7 @@ namespace sui4.MaterialPropertyBaker.Timeline
                 }
                 else
                 {
-                    clip.Props.UpdateShaderID();
+                    clip.Props.UpdateShaderIDs();
                 }
             }
 

--- a/Runtime/Timline/MaterialPropSwitcherMixerBehaviour.cs
+++ b/Runtime/Timline/MaterialPropSwitcherMixerBehaviour.cs
@@ -8,6 +8,7 @@ namespace sui4.MaterialPropertyBaker.Timeline
     {
         private readonly Dictionary<int, Color> _cMap = new();
         private readonly Dictionary<int, float> _fMap = new();
+        private readonly Dictionary<int, Texture> _tMap = new();
 
         private MaterialProps _matProps;
         private MaterialGroup _trackBinding;
@@ -24,6 +25,7 @@ namespace sui4.MaterialPropertyBaker.Timeline
 
             _cMap.Clear();
             _fMap.Clear();
+            _tMap.Clear();
             for (var i = 0; i < inputCount; i++)
             {
                 var inputWeight = playable.GetInputWeight(i);
@@ -48,21 +50,34 @@ namespace sui4.MaterialPropertyBaker.Timeline
                     totalWeight += inputWeight;
                     // 重み付き和じゃないといけないので、CreatePropertyBlockFromProfile は使えない
                     foreach (var cProp in _matProps.Colors)
+                    {
                         if (_cMap.ContainsKey(cProp.ID))
                             _cMap[cProp.ID] += cProp.Value * inputWeight;
                         else
                             _cMap.Add(cProp.ID, cProp.Value * inputWeight);
-
+                    }
+                    
                     foreach (var fProp in _matProps.Floats)
+                    {
                         if (_fMap.ContainsKey(fProp.ID))
                             _fMap[fProp.ID] += fProp.Value * inputWeight;
                         else
                             _fMap.Add(fProp.ID, fProp.Value * inputWeight);
+                    }
+
+
+                    foreach (var tProp in _matProps.Textures)
+                    {
+                        if (_tMap.ContainsKey(tProp.ID))
+                            _tMap[tProp.ID] = inputWeight > 0.5 ? tProp.Value : _tMap[tProp.ID];
+                        else
+                            _tMap.Add(tProp.ID, tProp.Value);
+                    }
                 }
             }
 
             if (totalWeight > 0f)
-                _trackBinding.SetPropertyBlock(_cMap, _fMap);
+                _trackBinding.SetPropertyBlock(_cMap, _fMap, _tMap);
             else
                 _trackBinding.ResetDefaultPropertyBlock();
         }

--- a/Runtime/Timline/MaterialPropSwitcherMixerBehaviour.cs
+++ b/Runtime/Timline/MaterialPropSwitcherMixerBehaviour.cs
@@ -56,7 +56,7 @@ namespace sui4.MaterialPropertyBaker.Timeline
                         else
                             _cMap.Add(cProp.ID, cProp.Value * inputWeight);
                     }
-                    
+
                     foreach (var fProp in _matProps.Floats)
                     {
                         if (_fMap.ContainsKey(fProp.ID))

--- a/Runtime/Timline/MultiMaterialProp/MultiMaterialPropMixerBehaviour.cs
+++ b/Runtime/Timline/MultiMaterialProp/MultiMaterialPropMixerBehaviour.cs
@@ -9,9 +9,11 @@ namespace sui4.MaterialPropertyBaker.Timeline
     {
         public readonly Dictionary<int, MaterialProp<Color>> ColorPropDict = new();
         public readonly Dictionary<int, MaterialProp<float>> FloatPropDict = new();
+        public readonly Dictionary<int, MaterialProp<Texture>> TexturePropDict = new();
 
         public List<MaterialProp<Color>> ColorProps => ColorPropDict.Values.ToList();
         public List<MaterialProp<float>> FloatProps => FloatPropDict.Values.ToList();
+        public List<MaterialProp<Texture>> TextureProps => TexturePropDict.Values.ToList();
     }
 
     public class MultiMaterialPropMixerBehaviour : PlayableBehaviour
@@ -82,6 +84,23 @@ namespace sui4.MaterialPropertyBaker.Timeline
                                     new MaterialProp<float>(fProps.Name, fProps.Value * inputWeight));
                         }
 
+                        // textureはblendingできない
+                        foreach (var tProps in preset.MaterialProps.Textures)
+                        {
+                            if (propShaderIDDict.TexturePropDict.ContainsKey(tProps.ID))
+                            {
+                                if (inputWeight > 0.5)
+                                {
+                                    propShaderIDDict.TexturePropDict[tProps.ID].Value = tProps.Value;
+                                }
+                            }
+                            else
+                            {
+                                propShaderIDDict.TexturePropDict.Add(tProps.ID,
+                                    new MaterialProp<Texture>(tProps.Name, tProps.Value));
+                            }
+                        }
+
                         _propDict.TryAdd(presetIDPair.ID, propShaderIDDict);
                     }
                 }
@@ -92,7 +111,7 @@ namespace sui4.MaterialPropertyBaker.Timeline
                 var prop = new Dictionary<string, MaterialProps>();
                 foreach (var (presetID, propShaderIDDict) in _propDict)
                 {
-                    prop.Add(presetID, new MaterialProps(propShaderIDDict.ColorProps, propShaderIDDict.FloatProps));
+                    prop.Add(presetID, new MaterialProps(propShaderIDDict.ColorProps, propShaderIDDict.FloatProps, propShaderIDDict.TextureProps));
                 }
 
                 _trackBinding.SetPropertyBlock(prop);

--- a/Runtime/Timline/MultiMaterialProp/MultiMaterialPropMixerBehaviour.cs
+++ b/Runtime/Timline/MultiMaterialProp/MultiMaterialPropMixerBehaviour.cs
@@ -111,7 +111,9 @@ namespace sui4.MaterialPropertyBaker.Timeline
                 var prop = new Dictionary<string, MaterialProps>();
                 foreach (var (presetID, propShaderIDDict) in _propDict)
                 {
-                    prop.Add(presetID, new MaterialProps(propShaderIDDict.ColorProps, propShaderIDDict.FloatProps, propShaderIDDict.TextureProps));
+                    prop.Add(presetID,
+                        new MaterialProps(propShaderIDDict.ColorProps, propShaderIDDict.FloatProps,
+                            propShaderIDDict.TextureProps));
                 }
 
                 _trackBinding.SetPropertyBlock(prop);

--- a/Runtime/Utils.cs
+++ b/Runtime/Utils.cs
@@ -29,7 +29,7 @@ namespace sui4.MaterialPropertyBaker
                 mpb.SetFloat(f.ID, f.Value);
             foreach (var t in props.Textures)
             {
-                if(t.Value != null)
+                if (t.Value != null)
                     mpb.SetTexture(t.ID, t.Value);
             }
         }
@@ -41,7 +41,7 @@ namespace sui4.MaterialPropertyBaker
             foreach (var (shaderID, value) in fPropMap) mpb.SetFloat(shaderID, value);
             foreach (var (shaderID, value) in tPropMap)
             {
-                if(value != null)
+                if (value != null)
                     mpb.SetTexture(shaderID, value);
             }
         }

--- a/Runtime/Utils.cs
+++ b/Runtime/Utils.cs
@@ -27,14 +27,23 @@ namespace sui4.MaterialPropertyBaker
                 mpb.SetColor(c.ID, c.Value);
             foreach (var f in props.Floats)
                 mpb.SetFloat(f.ID, f.Value);
+            foreach (var t in props.Textures)
+            {
+                if(t.Value != null)
+                    mpb.SetTexture(t.ID, t.Value);
+            }
         }
 
         public static void UpdatePropertyBlockFromDict(ref MaterialPropertyBlock mpb, Dictionary<int, Color> cPropMap,
-            Dictionary<int, float> fPropMap)
+            Dictionary<int, float> fPropMap, Dictionary<int, Texture> tPropMap)
         {
             foreach (var (shaderID, value) in cPropMap) mpb.SetColor(shaderID, value);
-
             foreach (var (shaderID, value) in fPropMap) mpb.SetFloat(shaderID, value);
+            foreach (var (shaderID, value) in tPropMap)
+            {
+                if(value != null)
+                    mpb.SetTexture(shaderID, value);
+            }
         }
 
         public static string UnderscoresToSpaces(string input)

--- a/Unity_MaterialPropertyBakerDemo~/Assets/PrimitiveDemo/Timeline/SampleTimeline.playable
+++ b/Unity_MaterialPropertyBakerDemo~/Assets/PrimitiveDemo/Timeline/SampleTimeline.playable
@@ -42,7 +42,76 @@ MonoBehaviour:
   m_Curves: {fileID: 0}
   m_Parent: {fileID: 11400000}
   m_Children: []
-  m_Clips: []
+  m_Clips:
+  - m_Version: 1
+    m_Start: 1.4
+    m_ClipIn: 0
+    m_Asset: {fileID: 5585299689099487117}
+    m_Duration: 5
+    m_TimeScale: 1
+    m_ParentTrack: {fileID: -5143360015990631233}
+    m_EaseInDuration: 0
+    m_EaseOutDuration: 0
+    m_BlendInDuration: -1
+    m_BlendOutDuration: -1
+    m_MixInCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    m_MixOutCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    m_BlendInCurveMode: 0
+    m_BlendOutCurveMode: 0
+    m_ExposedParameterNames: []
+    m_AnimationCurves: {fileID: 0}
+    m_Recordable: 0
+    m_PostExtrapolationMode: 0
+    m_PreExtrapolationMode: 0
+    m_PostExtrapolationTime: 0
+    m_PreExtrapolationTime: 0
+    m_DisplayName: Standard_properties_blue
   m_Markers:
     m_Objects: []
 --- !u!114 &11400000
@@ -440,3 +509,20 @@ MonoBehaviour:
   m_OpenClipOffsetRotation: {x: 0, y: 0, z: 0, w: 1}
   m_Rotation: {x: 0, y: 0, z: 0, w: 1}
   m_ApplyOffsets: 0
+--- !u!114 &5585299689099487117
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e860332b2b06bf4c9f8a41242ed3d25, type: 3}
+  m_Name: MaterialPropSwitcherClip
+  m_EditorClassIdentifier: 
+  _props:
+    _colors: []
+    _floats: []
+  _presetRef: {fileID: 11400000, guid: 5738ae6867b59b1499458b03029edfc8, type: 2}
+  _editable: 0

--- a/Unity_MaterialPropertyBakerDemo~/Assets/ZonkoDemo/MaterialPropertyBaker/Znk_BakedPropertyGroup.asset
+++ b/Unity_MaterialPropertyBakerDemo~/Assets/ZonkoDemo/MaterialPropertyBaker/Znk_BakedPropertyGroup.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3af66c4e4fc14402a426c33403f74793, type: 3}
+  m_Name: Znk_BakedPropertyGroup
+  m_EditorClassIdentifier: 
+  _presetIDPairs:
+  - _id: Face
+    _preset: {fileID: 11400000, guid: 92c75c1ed34daab4181b61dccd9ae418, type: 2}
+  - _id: Eye
+    _preset: {fileID: 0}
+  - _id: Body
+    _preset: {fileID: 0}

--- a/Unity_MaterialPropertyBakerDemo~/Assets/ZonkoDemo/MaterialPropertyBaker/Znk_BakedPropertyGroup.asset.meta
+++ b/Unity_MaterialPropertyBakerDemo~/Assets/ZonkoDemo/MaterialPropertyBaker/Znk_BakedPropertyGroup.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 641f0a6524cabf84f8964e71421cdc96
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity_MaterialPropertyBakerDemo~/Assets/ZonkoDemo/MaterialPropertyBaker/Znk_Dark.asset
+++ b/Unity_MaterialPropertyBakerDemo~/Assets/ZonkoDemo/MaterialPropertyBaker/Znk_Dark.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3af66c4e4fc14402a426c33403f74793, type: 3}
+  m_Name: Znk_Dark
+  m_EditorClassIdentifier: 
+  _presetIDPairs:
+  - _id: 
+    _preset: {fileID: 11400000, guid: 92c75c1ed34daab4181b61dccd9ae418, type: 2}

--- a/Unity_MaterialPropertyBakerDemo~/Assets/ZonkoDemo/MaterialPropertyBaker/Znk_Dark.asset.meta
+++ b/Unity_MaterialPropertyBakerDemo~/Assets/ZonkoDemo/MaterialPropertyBaker/Znk_Dark.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: abe72a48e77214641bcb8d8a24514c78
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity_MaterialPropertyBakerDemo~/Assets/ZonkoDemo/Zonko.unity
+++ b/Unity_MaterialPropertyBakerDemo~/Assets/ZonkoDemo/Zonko.unity
@@ -154,7 +154,9 @@ PlayableDirector:
   m_WrapMode: 2
   m_DirectorUpdateMode: 1
   m_InitialTime: 0
-  m_SceneBindings: []
+  m_SceneBindings:
+  - key: {fileID: -306108171692625359, guid: 79591e58db659a647b4be8102d825e3a, type: 2}
+    value: {fileID: 0}
   m_ExposedReferences:
     m_References: []
 --- !u!4 &276830326
@@ -208,7 +210,7 @@ MonoBehaviour:
     _values: []
   _renderers:
   - {fileID: 0}
-  _id: Group_ad3b700a-6532-499b-bbc8-6bf3fecd182b
+  _id: Eye
 --- !u!4 &280343277
 Transform:
   m_ObjectHideFlags: 0
@@ -260,7 +262,7 @@ MonoBehaviour:
     _values: []
   _renderers:
   - {fileID: 0}
-  _id: Group_109f0fd4-f3f2-4def-8b21-38c2e93b4eab
+  _id: Face
 --- !u!4 &519973630
 Transform:
   m_ObjectHideFlags: 0
@@ -493,8 +495,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _materialGroups:
   - {fileID: 519973629}
-  - {fileID: 1950335770}
   - {fileID: 280343276}
+  - {fileID: 1950335770}
 --- !u!4 &1299734792
 Transform:
   m_ObjectHideFlags: 0
@@ -549,7 +551,7 @@ MonoBehaviour:
     _values: []
   _renderers:
   - {fileID: 0}
-  _id: Group_59a933c7-11de-43da-bf9a-6b9a133d580c
+  _id: Body
 --- !u!4 &1950335771
 Transform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
- 一旦、MaterialGroupList componentのcontextmenu（ヘッダで右クリック）からプリセットグループを生成できるように（インターフェースはもっとわかりやすくしたほうが良いかも）
- プリセットグループのインスペクタで、中のプリセットを編集できるように。
- validate周り：shaderが一致しない場合は警告を出し、context menuからfixできるように
- Textureも扱えるように。ブレンディングは不可