### PR TITLE
DiffPropertyBakerでBakeした結果が保存されない問題を修正

### DIFF
--- a/Editor/DiffPropertyBaker.cs
+++ b/Editor/DiffPropertyBaker.cs
@@ -200,6 +200,9 @@ namespace sui4.MaterialPropertyBaker
                 }
             }
 
+            EditorUtility.SetDirty(_baseProfile);
+            AssetDatabase.SaveAssetIfDirty(_baseProfile);
+
             if (EditorUtility.DisplayDialog(
                     "Bake Succeeded",
                     $"Properties baked to {_baseProfile.name}",


### PR DESCRIPTION
## 概要
DiffPropertyBakerでBakeした結果が保存されない問題を修正

## 変更内容
* SetDrity()とSaveAssetifDirty()を追加しました
パッケージが2021.3以上推定なようなので、SaveAssetIfDirtyを使用しました