### PR TITLE
元マテリアルと差分がない場合にBake済みプロパティが更新されない問題を修正

### DIFF
--- a/Editor/DiffPropertyBaker.cs
+++ b/Editor/DiffPropertyBaker.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using PlasticGui.Configuration.CloudEdition.Welcome;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;

--- a/Editor/MPBEditorUtils.cs
+++ b/Editor/MPBEditorUtils.cs
@@ -95,6 +95,58 @@ namespace sui4.MaterialPropertyBaker
                 }
             }
         }
+
+        // すでにMaterialPropsにあるプロパティの値をtargetMatから取得してpropHoldersに格納する
+        public static void GetLatestValueOfBakedProperties(MaterialProps matProps, Material targetMat, ref List<BaseTargetValueHolder> propHolders)
+        {
+            if (matProps.Shader != targetMat.shader)
+            {
+                Debug.LogWarning($"Baked properties and Material({targetMat.name}) have different shaders.");
+                return;
+            }
+
+            for (var pi = 0; pi < targetMat.shader.GetPropertyCount(); pi++)
+            {
+                string propName = targetMat.shader.GetPropertyName(pi);
+                ShaderPropertyType propType = targetMat.shader.GetPropertyType(pi);
+                
+                if (!matProps.HasProperty(propName, propType)) continue;
+
+                var baseTargetValueHolder = new BaseTargetValueHolder()
+                {
+                    PropName = propName,
+                    PropType = propType,
+                };
+                switch (propType)
+                {
+                    case ShaderPropertyType.Color:
+                        Color targetColor = targetMat.GetColor(propName);
+                        baseTargetValueHolder.TargetColorValue = targetColor;
+                        propHolders.Add(baseTargetValueHolder);
+
+                        break;
+                    case ShaderPropertyType.Float:
+                    case ShaderPropertyType.Range:
+                        float targetFloat = targetMat.GetFloat(propName);
+                        baseTargetValueHolder.TargetFloatValue = targetFloat;
+                        propHolders.Add(baseTargetValueHolder);
+
+                        break;
+                    case ShaderPropertyType.Int:
+                        int targetInt = targetMat.GetInteger(propName);
+                        baseTargetValueHolder.TargetIntValue = targetInt;
+                        propHolders.Add(baseTargetValueHolder);
+
+                        break;
+                    case ShaderPropertyType.Texture:
+                    case ShaderPropertyType.Vector:
+                    default:
+                        // not supported
+                        break;
+                }
+            }
+        }
+        
         
         // float と range はともにfloatのため一致した型として扱う
         public static bool IsMatchShaderType(ShaderPropertyType s1, ShaderPropertyType s2)

--- a/Editor/MPBEditorUtils.cs
+++ b/Editor/MPBEditorUtils.cs
@@ -29,10 +29,11 @@ namespace sui4.MaterialPropertyBaker
     }
     public static class MPBEditorUtils
     {
+        // 2つのマテリアルのプロパティを比較して、違うものをpropHoldersに格納する
         public static void GetDifferentProperties(Material baseMat, Material targetMat,
-            out List<BaseTargetValueHolder> differentProps)
+            out List<BaseTargetValueHolder> propHolders)
         {
-            differentProps = new List<BaseTargetValueHolder>();
+            propHolders = new List<BaseTargetValueHolder>();
             const float tolerance = 0.0001f;
             if (baseMat.shader != targetMat.shader)
             {
@@ -59,7 +60,7 @@ namespace sui4.MaterialPropertyBaker
                         {
                             baseTargetValueHolder.BaseColorValue = baseColor;
                             baseTargetValueHolder.TargetColorValue = targetColor;
-                            differentProps.Add(baseTargetValueHolder);
+                            propHolders.Add(baseTargetValueHolder);
                         }
 
                         break;
@@ -71,7 +72,7 @@ namespace sui4.MaterialPropertyBaker
                         {
                             baseTargetValueHolder.BaseFloatValue = baseFloat;
                             baseTargetValueHolder.TargetFloatValue = targetFloat;
-                            differentProps.Add(baseTargetValueHolder);
+                            propHolders.Add(baseTargetValueHolder);
                         }
 
                         break;
@@ -82,7 +83,7 @@ namespace sui4.MaterialPropertyBaker
                         {
                             baseTargetValueHolder.BaseIntValue = baseInt;
                             baseTargetValueHolder.TargetIntValue = targetInt;
-                            differentProps.Add(baseTargetValueHolder);
+                            propHolders.Add(baseTargetValueHolder);
                         }
 
                         break;

--- a/Editor/MaterialFinder.cs
+++ b/Editor/MaterialFinder.cs
@@ -1,5 +1,4 @@
-﻿#if UNITY_EDITOR
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
@@ -45,5 +44,3 @@ namespace sui4.MaterialPropertyBaker
         }
     }
 }
-
-#endif

--- a/Editor/PropertyModifier.cs
+++ b/Editor/PropertyModifier.cs
@@ -214,6 +214,7 @@ namespace sui4.MaterialPropertyBaker
                         if (GUILayout.Button("Bake Modified Properties"))
                         {
                             MPBEditorUtils.GetDifferentProperties(mat, _copiedMaterialList[index], out List<BaseTargetValueHolder> differentProps);
+                            MPBEditorUtils.GetLatestValueOfBakedProperties(materialProps, _copiedMaterialList[index], ref differentProps);
                             BakeToMatProps(materialProps, differentProps);
                             EditorUtility.SetDirty(_profile);
                             AssetDatabase.SaveAssetIfDirty(_profile);

--- a/Editor/PropertyModifier.cs
+++ b/Editor/PropertyModifier.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
-using UnityEngine.PlayerLoop;
 using UnityEngine.Rendering;
 using Object = UnityEngine.Object;
 


### PR DESCRIPTION
resolve #50 
差分のあるプロパティだけでなく、Bake済みのプロパティについても編集用マテリアルの値を格納することで対応