### PR TITLE
material, rendererのnull checkを追加

### DIFF
--- a/Runtime/TargetGroup.cs
+++ b/Runtime/TargetGroup.cs
@@ -157,6 +157,7 @@ namespace sui4.MaterialPropertyBaker
                 for (var mi = 0; mi < ren.sharedMaterials.Length; mi++)
                 {
                     Material mat = ren.sharedMaterials[mi];
+                    if (mat == null) continue;
                     TargetInfo targetInfo = wrapper.MatTargetInfoDict[mat];
                     MaterialProps defaultProps = DefaultMaterialPropsDict[mat];
                     // ren.GetPropertyBlock(_mpb, mi); // 初期化時にsetしてるため、ここで例外は発生しないはず
@@ -268,7 +269,12 @@ namespace sui4.MaterialPropertyBaker
             _mpb = new MaterialPropertyBlock();
             foreach (Renderer ren in Renderers)
                 for (var mi = 0; mi < ren.sharedMaterials.Length; mi++)
-                    ren.SetPropertyBlock(_mpb, mi);
+                {
+                    if (ren.sharedMaterials[mi] != null)
+                    {
+                        ren.SetPropertyBlock(_mpb, mi);
+                    }
+                }
         }
 
         public void ResetToDefault()

--- a/Runtime/TargetGroup.cs
+++ b/Runtime/TargetGroup.cs
@@ -210,10 +210,15 @@ namespace sui4.MaterialPropertyBaker
             {
                 MaterialProp<int> prop = defaultProps.Ints.Find(c => c.ID == i.ID);
                 if (prop == null) continue;
-                if (usedPropWeightDict.TryGetValue(prop.ID, out var storedWeight) && weight > storedWeight)
+                // int型は重み付き和が求められないため、weightが大きい方を優先する
+                // NOTE: 重み付き和をもとめたあとに近い値に丸めるという方法もありそう。ただ、どのタイミングで丸めるかが問題になりそう
+                if (usedPropWeightDict.TryGetValue(prop.ID, out float storedWeight))
                 {
-                    mpb.SetInt(prop.ID, i.Value);
-                    usedPropWeightDict[prop.ID] = weight;
+                    if (weight > storedWeight)
+                    {
+                        mpb.SetInt(prop.ID, i.Value);
+                        usedPropWeightDict[prop.ID] = weight; 
+                    }
                 }
                 else
                 {

--- a/Runtime/TargetGroup.cs
+++ b/Runtime/TargetGroup.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.Assertions;
 
 namespace sui4.MaterialPropertyBaker
 {
@@ -58,6 +59,7 @@ namespace sui4.MaterialPropertyBaker
                 MaterialTargetInfoSDictWrapper wrapper = RendererMatTargetInfoWrapperDict[ren];
                 foreach (Material mat in wrapper.MatTargetInfoDict.Keys)
                 {
+                    Assert.IsNotNull(mat);
                     var defaultProps = new MaterialProps(mat);
                     DefaultMaterialPropsDict.TryAdd(mat, defaultProps);
                 }
@@ -229,7 +231,7 @@ namespace sui4.MaterialPropertyBaker
             }
         }
 
-        // 個別に設定された値を優先する
+        // globalと個別の両方で同じPropertyの値が設定されていた場合、個別に設定された値を優先する
         private static void MergeGlobalProps(MpbProfile profile, out Dictionary<string, MaterialProps> mergedPropsDict)
         {
             mergedPropsDict = new Dictionary<string, MaterialProps>();
@@ -241,6 +243,7 @@ namespace sui4.MaterialPropertyBaker
         }
 
 
+        // mergeするのはpropertyの項目のみ。各propertyの値はmergeしない
         // layerが上(indexが大きい)のを優先する
         private static MaterialProps MergeMaterialProps(in IReadOnlyList<MaterialProps> layeredProps)
         {

--- a/Runtime/TargetGroup.cs
+++ b/Runtime/TargetGroup.cs
@@ -157,6 +157,7 @@ namespace sui4.MaterialPropertyBaker
 
             foreach (Renderer ren in Renderers)
             {
+                if(ren == null) continue;
                 MaterialTargetInfoSDictWrapper wrapper = RendererMatTargetInfoWrapperDict[ren];
                 for (var mi = 0; mi < ren.sharedMaterials.Length; mi++)
                 {
@@ -275,13 +276,16 @@ namespace sui4.MaterialPropertyBaker
         {
             _mpb = new MaterialPropertyBlock();
             foreach (Renderer ren in Renderers)
+            {
+                if(ren == null) continue;
                 for (var mi = 0; mi < ren.sharedMaterials.Length; mi++)
                 {
                     if (ren.sharedMaterials[mi] != null)
                     {
                         ren.SetPropertyBlock(_mpb, mi);
                     }
-                }
+                } 
+            }
         }
 
         public void ResetToDefault()
@@ -297,6 +301,7 @@ namespace sui4.MaterialPropertyBaker
             Dictionary<Shader, int> matNumDict = new();
             foreach (Renderer ren in Renderers)
             {
+                if(ren == null) continue;
                 MaterialTargetInfoSDictWrapper wrapper = RendererMatTargetInfoWrapperDict[ren];
                 for (var mi = 0; mi < ren.sharedMaterials.Length; mi++)
                 {

--- a/Runtime/TargetGroup.cs
+++ b/Runtime/TargetGroup.cs
@@ -118,8 +118,10 @@ namespace sui4.MaterialPropertyBaker
             var renderersToRemove = new List<Renderer>();
             foreach (Renderer ren in Renderers)
             {
-                if (renderers.Contains(ren)) continue;
-                renderersToRemove.Add(ren);
+                if (!renderers.Contains(ren))
+                {
+                    renderersToRemove.Add(ren);
+                }
             }
 
             foreach (Renderer ren in renderersToRemove)
@@ -128,17 +130,13 @@ namespace sui4.MaterialPropertyBaker
                 RendererMatTargetInfoWrapperDict.Remove(ren);
             }
 
-            var renderersToAdd = new List<Renderer>();
             foreach (Renderer ren in renderers)
             {
-                if (Renderers.Contains(ren)) continue;
-                renderersToAdd.Add(ren);
-            }
-
-            foreach (Renderer ren in renderersToAdd)
-            {
-                Renderers.Add(ren);
-                RendererMatTargetInfoWrapperDict.TryAdd(ren, new MaterialTargetInfoSDictWrapper());
+                if (!Renderers.Contains(ren))
+                {
+                    Renderers.Add(ren);
+                    RendererMatTargetInfoWrapperDict.TryAdd(ren, new MaterialTargetInfoSDictWrapper());
+                }
             }
         }
 

--- a/Runtime/TargetGroup.cs
+++ b/Runtime/TargetGroup.cs
@@ -75,11 +75,17 @@ namespace sui4.MaterialPropertyBaker
                 // 削除されたmaterialを取り除く
                 var matKeysToRemove = new List<Material>();
                 foreach (Material mat in matTargetInfoSDictWrapper.MatTargetInfoDict.Keys)
+                {
                     if (!ren.sharedMaterials.Contains(mat))
+                    {
                         matKeysToRemove.Add(mat);
+                    }
+                }
 
                 foreach (Material mat in matKeysToRemove)
+                {
                     matTargetInfoSDictWrapper.MatTargetInfoDict.Remove(mat);
+                }
 
                 // 追加されたmaterialを追加する
                 foreach (Material mat in ren.sharedMaterials)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "name": "jp.sui4.materialpropertybaker",
   "repository": "github:sui4/MaterialPropertyBaker",
   "unity": "2021.3",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "tool"
 }


### PR DESCRIPTION
- Set/Reset Property Block時にmaterialがnullの場合スキップする。
- 実行時にRendererが削除されることもあるため、Rendererリストでループを回す際はすべてnull checkを行う。
- int propertyのマージ処理にミスがあったのを修正。