### PR TITLE
MaterialPropsの複数レイヤーの結合関数のリファクタリング + MaterialPropsのコンストラクタ修正

### DIFF
--- a/Runtime/MateiralProps.cs
+++ b/Runtime/MateiralProps.cs
@@ -22,9 +22,9 @@ namespace sui4.MaterialPropertyBaker
 
         public MaterialProps(List<MaterialProp<Color>> c, List<MaterialProp<float>> f, List<MaterialProp<int>> i)
         {
-            Colors.AddRange(c);
-            Floats.AddRange(f);
-            Ints.AddRange(i);
+            Colors = new List<MaterialProp<Color>>(c);
+            Floats = new List<MaterialProp<float>>(f);
+            Ints = new List<MaterialProp<int>>(i);
             UpdateShaderID();
         }
 

--- a/Runtime/MateiralProps.cs
+++ b/Runtime/MateiralProps.cs
@@ -22,9 +22,12 @@ namespace sui4.MaterialPropertyBaker
 
         public MaterialProps(List<MaterialProp<Color>> c, List<MaterialProp<float>> f, List<MaterialProp<int>> i)
         {
-            Colors = new List<MaterialProp<Color>>(c);
-            Floats = new List<MaterialProp<float>>(f);
-            Ints = new List<MaterialProp<int>>(i);
+            CopyProperties(c, out List<MaterialProp<Color>> deepCopiedColors);
+            CopyProperties(f, out List<MaterialProp<float>> deepCopiedFloats);
+            CopyProperties(i, out List<MaterialProp<int>> deepCopiedInts);
+            _colors = deepCopiedColors;
+            _floats = deepCopiedFloats;
+            _ints = deepCopiedInts;
             UpdateShaderID();
         }
 
@@ -83,23 +86,11 @@ namespace sui4.MaterialPropertyBaker
             set => _material = value;
         }
 
-        public List<MaterialProp<Color>> Colors
-        {
-            get => _colors;
-            set => _colors = value;
-        }
+        public List<MaterialProp<Color>> Colors => _colors;
 
-        public List<MaterialProp<float>> Floats
-        {
-            get => _floats;
-            set => _floats = value;
-        }
-        
-        public List<MaterialProp<int>> Ints
-        {
-            get => _ints;
-            set => _ints = value;
-        }
+        public List<MaterialProp<float>> Floats => _floats;
+
+        public List<MaterialProp<int>> Ints => _ints;
 
         public bool IsEmpty()
         {
@@ -201,7 +192,6 @@ namespace sui4.MaterialPropertyBaker
             }
         }
 
-
         public bool HasProperty(string propName, ShaderPropertyType spType)
         {
             if (IsSupportedType(spType))
@@ -253,9 +243,9 @@ namespace sui4.MaterialPropertyBaker
                 out List<MaterialProp<Color>> outC,
                 out List<MaterialProp<float>> outF,
                 out List<MaterialProp<int>> outI);
-            Colors = outC;
-            Floats = outF;
-            Ints = outI;
+            _colors = outC;
+            _floats = outF;
+            _ints = outI;
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "name": "jp.sui4.materialpropertybaker",
   "repository": "github:sui4/MaterialPropertyBaker",
   "unity": "2021.3",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "tool"
 }


### PR DESCRIPTION
レイヤー統合は無駄なコピーをなくすことでパフォーマンスを改善（したはず）。

public MaterialProps(List<MaterialProp<Color>> c, List<MaterialProp<float>> f, List<MaterialProp<int>> i)
がdeepcopyになってなかったのを修正