### PR TITLE
Textureの暫定的なサポートを追加

### DIFF
--- a/Editor/DiffPropertyBaker.cs
+++ b/Editor/DiffPropertyBaker.cs
@@ -140,7 +140,11 @@ namespace sui4.MaterialPropertyBaker
                             EditorGUILayout.IntField(new GUIContent(prop.PropName), prop.TargetIntValue);
                             break;
                         case ShaderPropertyType.Vector:
+                            break;
                         case ShaderPropertyType.Texture:
+                            EditorGUILayout.ObjectField(new GUIContent(prop.PropName), prop.BaseTextureValue, typeof(Texture), allowSceneObjects:false);
+                            EditorGUILayout.ObjectField(new GUIContent(prop.PropName), prop.TargetTextureValue, typeof(Texture), allowSceneObjects:false);
+                            break;
                         default:
                             Debug.LogWarning(
                                 $"Property type {prop.PropType} is not supported. Skipped. (This should not happen))");
@@ -192,7 +196,10 @@ namespace sui4.MaterialPropertyBaker
                                 targetMatProps.SetInt(prop.PropName, prop.TargetIntValue);
                                 break;
                             case ShaderPropertyType.Vector:
+                                break;
                             case ShaderPropertyType.Texture:
+                                targetMatProps.SetTexture(prop.PropName, prop.TargetTextureValue);
+                                break;
                             default:
                                 Debug.LogWarning(
                                     $"Property type {prop.PropType} is not supported. Skipped. (This should not happen))");

--- a/Editor/MPBEditorUtils.cs
+++ b/Editor/MPBEditorUtils.cs
@@ -22,9 +22,11 @@ namespace sui4.MaterialPropertyBaker
         public Color BaseColorValue;
         public float BaseFloatValue;
         public int BaseIntValue;
+        public Texture BaseTextureValue;
         public Color TargetColorValue;
         public float TargetFloatValue;
         public int TargetIntValue;
+        public Texture TargetTextureValue;
     }
     public static class MPBEditorUtils
     {
@@ -93,7 +95,19 @@ namespace sui4.MaterialPropertyBaker
 
                         break;
                     case ShaderPropertyType.Texture:
+
+                        break;
                     case ShaderPropertyType.Vector:
+                        Texture baseTexture = baseMat.GetTexture(propName);
+                        Texture targetTexture = targetMat.GetTexture(propName);
+                        if (baseTexture != targetTexture)
+                        {
+                            baseTargetValueHolder.BaseTextureValue = baseTexture;
+                            baseTargetValueHolder.TargetTextureValue = targetTexture;
+                            propHolders.Add(baseTargetValueHolder);
+                        }
+
+                        break;
                     default:
                         // not supported
                         break;
@@ -144,7 +158,14 @@ namespace sui4.MaterialPropertyBaker
 
                         break;
                     case ShaderPropertyType.Texture:
+                        Texture targetTexture = targetMat.GetTexture(propName);
+                        baseTargetValueHolder.TargetTextureValue = targetTexture;
+                        propHolders.Add(baseTargetValueHolder);
+
+                        break;
                     case ShaderPropertyType.Vector:
+
+                        break;
                     default:
                         // not supported
                         break;

--- a/Editor/MaterialPropsPropertyDrawer.cs
+++ b/Editor/MaterialPropsPropertyDrawer.cs
@@ -9,6 +9,7 @@ namespace sui4.MaterialPropertyBaker
         private SerializedProperty _colors;
         private SerializedProperty _floats;
         private SerializedProperty _ints;
+        private SerializedProperty _textures;
         private SerializedProperty _id;
 
         private SerializedProperty _property;
@@ -24,6 +25,7 @@ namespace sui4.MaterialPropertyBaker
             _colors = property.FindPropertyRelative("_colors");
             _floats = property.FindPropertyRelative("_floats");
             _ints = property.FindPropertyRelative("_ints");
+            _textures = property.FindPropertyRelative("_textures");
 
             EditorGUILayout.PropertyField(_id);
             EditorGUILayout.PropertyField(_shader);
@@ -48,6 +50,12 @@ namespace sui4.MaterialPropertyBaker
             EditorGUILayout.LabelField("Ints", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
             PropsGUI(_ints);
+            EditorGUI.indentLevel--;
+            
+            // Textures
+            EditorGUILayout.LabelField("Textures", EditorStyles.boldLabel);
+            EditorGUI.indentLevel++;
+            PropsGUI(_textures);
             EditorGUI.indentLevel--;
 
             EditorGUI.EndProperty();

--- a/Editor/PropertyModifier.cs
+++ b/Editor/PropertyModifier.cs
@@ -18,6 +18,7 @@ namespace sui4.MaterialPropertyBaker
         private readonly List<bool> _colorsFoldoutList = new();
         private readonly List<bool> _floatsFoldoutList = new();
         private readonly List<bool> _intsFoldoutList = new();
+        private readonly List<bool> _texturesFoldoutList = new();
 
         private SerializedProperty _materialPropsListProp;
         private SerializedProperty _materialPropsProp;
@@ -39,6 +40,7 @@ namespace sui4.MaterialPropertyBaker
         private static string ColorsFoldoutKeyAt(string targetName, string id) => $"{targetName}_colorsFoldout_{id}";
         private static string FloatsFoldoutKeyAt(string targetName, string id) => $"{targetName}_floatsFoldout_{id}";
         private static string IntsFoldoutKeyAt(string targetName, string id) => $"{targetName}_intsFoldout_{id}";
+        private static string TexturesFoldoutKeyAt(string targetName, string id) => $"{targetName}_textureFoldout_{id}";
 
         private void OnSwitchProfile()
         {
@@ -64,6 +66,7 @@ namespace sui4.MaterialPropertyBaker
                 _colorsFoldoutList.Add(SessionState.GetBool(ColorsFoldoutKeyAt(targetName, id), true));
                 _floatsFoldoutList.Add(SessionState.GetBool(FloatsFoldoutKeyAt(targetName, id), true));
                 _intsFoldoutList.Add(SessionState.GetBool(IntsFoldoutKeyAt(targetName, id), true));
+                _texturesFoldoutList.Add(SessionState.GetBool(TexturesFoldoutKeyAt(targetName, id), true));
             }
 
             _materialEditor.Clear();
@@ -155,6 +158,7 @@ namespace sui4.MaterialPropertyBaker
             SerializedProperty colors = materialPropsProp.FindPropertyRelative("_colors");
             SerializedProperty floats = materialPropsProp.FindPropertyRelative("_floats");
             SerializedProperty ints = materialPropsProp.FindPropertyRelative("_ints");
+            SerializedProperty textures = materialPropsProp.FindPropertyRelative("_textures");
 
             EditorGUILayout.PropertyField(id, new GUIContent("ID"));
             EditorGUILayout.PropertyField(material);
@@ -252,6 +256,16 @@ namespace sui4.MaterialPropertyBaker
                         //     PropsGUI(ints, Target.MaterialPropsList[index], ShaderPropertyType.Int);
                         //     EditorGUI.indentLevel--;
                         // }
+                        
+                        // Textures
+                        _texturesFoldoutList[index] = EditorGUILayout.Foldout(_texturesFoldoutList[index], "Textures");
+                        SessionState.SetBool(TexturesFoldoutKeyAt(targetProfile.name, key), _texturesFoldoutList[index]);
+                        if (_texturesFoldoutList[index])
+                        {
+                            EditorGUI.indentLevel++;
+                            PropsGUI(textures, targetProfile.MaterialPropsList[index], ShaderPropertyType.Texture, targetShader);
+                            EditorGUI.indentLevel--;
+                        }
                     }
                 }
             }
@@ -274,7 +288,13 @@ namespace sui4.MaterialPropertyBaker
                         matProps.SetInt(prop.PropName, prop.TargetIntValue);
                         break;
                     case ShaderPropertyType.Vector:
+                        break;
                     case ShaderPropertyType.Texture:
+                        if (prop.TargetTextureValue != null)
+                        {
+                            matProps.SetTexture(prop.PropName, prop.TargetTextureValue);
+                        }
+                        break;
                     default:
                         Debug.LogWarning(
                             $"Property type {prop.PropType} is not supported. Skipped. (This should not happen))");
@@ -293,6 +313,11 @@ namespace sui4.MaterialPropertyBaker
             foreach (MaterialProp<float> floatProp in matProps.Floats)
             {
                 targetMat.SetFloat(floatProp.Name, floatProp.Value);
+            }
+            
+            foreach(MaterialProp<Texture> textureProp in matProps.Textures)
+            {
+                targetMat.SetTexture(textureProp.Name, textureProp.Value);
             }
         }
 
@@ -432,7 +457,10 @@ namespace sui4.MaterialPropertyBaker
                             EditorGUILayout.PropertyField(valueProp, new GUIContent(label));
                             break;
                         case ShaderPropertyType.Vector:
+                            break;
                         case ShaderPropertyType.Texture:
+                            EditorGUILayout.PropertyField(valueProp, new GUIContent(label));
+                            break;
                         default:
                             break;
                     }

--- a/Runtime/MateiralProps.cs
+++ b/Runtime/MateiralProps.cs
@@ -15,19 +15,22 @@ namespace sui4.MaterialPropertyBaker
         [SerializeField] private List<MaterialProp<Color>> _colors = new();
         [SerializeField] private List<MaterialProp<float>> _floats = new();
         [SerializeField] private List<MaterialProp<int>> _ints = new();
+        [SerializeField] private List<MaterialProp<Texture>> _textures = new();
 
         public MaterialProps()
         {
         }
 
-        public MaterialProps(List<MaterialProp<Color>> c, List<MaterialProp<float>> f, List<MaterialProp<int>> i)
+        public MaterialProps(List<MaterialProp<Color>> c, List<MaterialProp<float>> f, List<MaterialProp<int>> i, List<MaterialProp<Texture>> t)
         {
             CopyProperties(c, out List<MaterialProp<Color>> deepCopiedColors);
             CopyProperties(f, out List<MaterialProp<float>> deepCopiedFloats);
             CopyProperties(i, out List<MaterialProp<int>> deepCopiedInts);
+            CopyProperties(t, out List<MaterialProp<Texture>> deepCopiedTextures);
             _colors = deepCopiedColors;
             _floats = deepCopiedFloats;
             _ints = deepCopiedInts;
+            _textures = deepCopiedTextures;
             UpdateShaderID();
         }
 
@@ -60,7 +63,11 @@ namespace sui4.MaterialPropertyBaker
                             Ints.Add(new MaterialProp<int>(propName, i));
                             break;
                         case ShaderPropertyType.Vector:
+                            break;
                         case ShaderPropertyType.Texture:
+                            Texture t = mat.GetTexture(propName);
+                            Textures.Add(new MaterialProp<Texture>(propName, t));
+                            break;
                         default:
                             break;
                     }
@@ -91,10 +98,12 @@ namespace sui4.MaterialPropertyBaker
         public List<MaterialProp<float>> Floats => _floats;
 
         public List<MaterialProp<int>> Ints => _ints;
+        
+        public List<MaterialProp<Texture>> Textures => _textures;
 
         public bool IsEmpty()
         {
-            return Colors.Count == 0 && Floats.Count == 0 && Ints.Count == 0;
+            return Colors.Count == 0 && Floats.Count == 0 && Ints.Count == 0 && Textures.Count == 0;
         }
 
         public static bool IsSupportedType(ShaderPropertyType type)
@@ -106,7 +115,7 @@ namespace sui4.MaterialPropertyBaker
                 ShaderPropertyType.Range => true,
                 ShaderPropertyType.Int => true,
                 ShaderPropertyType.Vector => false,
-                ShaderPropertyType.Texture => false,
+                ShaderPropertyType.Texture => true,
                 _ => false
             };
         }
@@ -121,6 +130,9 @@ namespace sui4.MaterialPropertyBaker
             
             foreach (MaterialProp<int> i in Ints)
                 i.UpdateShaderID();
+            
+            foreach (MaterialProp<Texture> t in Textures)
+                t.UpdateShaderID();
         }
 
         // add property with default value
@@ -140,7 +152,10 @@ namespace sui4.MaterialPropertyBaker
                     Ints.Add(new MaterialProp<int>(propName));
                     break;
                 case ShaderPropertyType.Vector:
+                    break;
                 case ShaderPropertyType.Texture:
+                    Textures.Add(new MaterialProp<Texture>(propName));
+                    break;
                 default:
                     Debug.LogWarning($"Not supported property type. {spType}");
                     break;
@@ -182,6 +197,18 @@ namespace sui4.MaterialPropertyBaker
                 Ints.Add(new MaterialProp<int>(propName, value));
             }
         }
+        
+        public void SetTexture(string propName, Texture value)
+        {
+            if (HasProperty(propName, ShaderPropertyType.Texture))
+            {
+                UpdateProperty(Textures, propName, value);
+            }
+            else
+            {
+                Textures.Add(new MaterialProp<Texture>(propName, value));
+            }
+        }
 
         private void UpdateProperty<T>(List<MaterialProp<T>> props, string propName, T value)
         {
@@ -203,7 +230,7 @@ namespace sui4.MaterialPropertyBaker
                     ShaderPropertyType.Range => Floats.Any(materialProp => materialProp.Name == propName),
                     ShaderPropertyType.Int => Ints.Any(materialProp => materialProp.Name == propName),
                     ShaderPropertyType.Vector => false,
-                    ShaderPropertyType.Texture => false,
+                    ShaderPropertyType.Texture => Textures.Any(materialProp => materialProp.Name == propName),
                     _ => false
                 };
             }
@@ -214,12 +241,12 @@ namespace sui4.MaterialPropertyBaker
             }
         }
 
-        public void GetCopyProperties(out List<MaterialProp<Color>> cList, out List<MaterialProp<float>> fList, out List<MaterialProp<int>> iList)
+        public void GetCopyProperties(out List<MaterialProp<Color>> cList, out List<MaterialProp<float>> fList, out List<MaterialProp<int>> iList, out List<MaterialProp<Texture>> tList)
         {
-            // Listになってる各MaterialPropがクラスのため、単純にやると参照渡しになって、変更が同期されてしまう
             CopyProperties(Colors, out cList);
             CopyProperties(Floats, out fList);
             CopyProperties(Ints, out iList);
+            CopyProperties(Textures, out tList);
         }
 
         private void CopyProperties<T>(in List<MaterialProp<T>> baseProps, out List<MaterialProp<T>> targetProps)
@@ -242,10 +269,12 @@ namespace sui4.MaterialPropertyBaker
             other.GetCopyProperties(
                 out List<MaterialProp<Color>> outC,
                 out List<MaterialProp<float>> outF,
-                out List<MaterialProp<int>> outI);
+                out List<MaterialProp<int>> outI,
+                out List<MaterialProp<Texture>> outT);
             _colors = outC;
             _floats = outF;
             _ints = outI;
+            _textures = outT;
         }
     }
 

--- a/Runtime/TargetGroup.cs
+++ b/Runtime/TargetGroup.cs
@@ -246,6 +246,31 @@ namespace sui4.MaterialPropertyBaker
                     usedPropWeightDict.Add(prop.ID, weight);
                 }
             }
+            
+            foreach (MaterialProp<Texture> t in propsToAdd.Textures)
+            {
+                MaterialProp<Texture> prop = defaultProps.Textures.Find(c => c.ID == t.ID);
+                if (prop == null) continue;
+                if (usedPropWeightDict.TryGetValue(prop.ID, out float storedWeight))
+                {
+                    if (weight > storedWeight)
+                    {
+                        if (t.Value != null)
+                        {
+                            mpb.SetTexture(prop.ID, t.Value);
+                        }
+                        usedPropWeightDict[prop.ID] = weight; 
+                    }
+                }
+                else
+                {
+                    if (t.Value != null)
+                    {
+                        mpb.SetTexture(prop.ID, t.Value);
+                    }
+                    usedPropWeightDict.Add(prop.ID, weight);
+                }
+            }
         }
 
         // globalと個別の両方で同じPropertyの値が設定されていた場合、個別に設定された値を優先する
@@ -271,10 +296,11 @@ namespace sui4.MaterialPropertyBaker
             if (layeredProps.Count > 0)
             {
                 MaterialProps firstLayer = layeredProps[^1];
-                mergedProps = new MaterialProps(firstLayer.Colors, firstLayer.Floats, firstLayer.Ints);
+                mergedProps = new MaterialProps(firstLayer.Colors, firstLayer.Floats, firstLayer.Ints, firstLayer.Textures);
                 addedPropIds.UnionWith(firstLayer.Colors?.Select(colorProp => colorProp.ID) ?? Enumerable.Empty<int>());
                 addedPropIds.UnionWith(firstLayer.Floats?.Select(floatProp => floatProp.ID) ?? Enumerable.Empty<int>());
                 addedPropIds.UnionWith(firstLayer.Ints?.Select(intProp => intProp.ID) ?? Enumerable.Empty<int>());
+                addedPropIds.UnionWith(firstLayer.Textures?.Select(textureProp => textureProp.ID) ?? Enumerable.Empty<int>());
             }
 
             // 残りのレイヤー
@@ -292,6 +318,11 @@ namespace sui4.MaterialPropertyBaker
                 foreach (MaterialProp<int> intProp in target.Ints)
                 {
                     if(!addedPropIds.Contains(intProp.ID)) mergedProps.Ints.Add(intProp);
+                }
+
+                foreach (MaterialProp<Texture> textureProp in target.Textures)
+                {
+                    if(!addedPropIds.Contains(textureProp.ID)) mergedProps.Textures.Add(textureProp);
                 }
             }
 

--- a/Runtime/TargetGroup.cs
+++ b/Runtime/TargetGroup.cs
@@ -264,11 +264,14 @@ namespace sui4.MaterialPropertyBaker
                 }
                 else
                 {
-                    if (t.Value != null)
+                    if (weight > 0.5)
                     {
-                        mpb.SetTexture(prop.ID, t.Value);
+                        if (t.Value != null)
+                        {
+                            mpb.SetTexture(prop.ID, t.Value);
+                        }
+                        usedPropWeightDict.Add(prop.ID, weight);
                     }
-                    usedPropWeightDict.Add(prop.ID, weight);
                 }
             }
         }

--- a/Runtime/Utils.cs
+++ b/Runtime/Utils.cs
@@ -22,16 +22,20 @@ namespace sui4.MaterialPropertyBaker
                 mpb.SetFloat(f.ID, f.Value);
             foreach (MaterialProp<int> i in props.Ints)
                 mpb.SetInteger(i.ID, i.Value);
+            foreach (MaterialProp<Texture> t in props.Textures)
+                mpb.SetTexture(t.ID, t.Value);
         }
 
         public static void UpdatePropertyBlockFromDict(ref MaterialPropertyBlock mpb, Dictionary<int, Color> cPropDict,
-            Dictionary<int, float> fPropDict, Dictionary<int, int> iPropDict)
+            Dictionary<int, float> fPropDict, Dictionary<int, int> iPropDict, Dictionary<int, Texture> tPropDict)
         {
             foreach ((int shaderID, Color value) in cPropDict) mpb.SetColor(shaderID, value);
 
             foreach ((int shaderID, float value) in fPropDict) mpb.SetFloat(shaderID, value);
             
             foreach ((int shaderID, int value) in iPropDict) mpb.SetInteger(shaderID, value);
+            
+            foreach ((int shaderID, Texture value) in tPropDict) mpb.SetTexture(shaderID, value);
         }
 
         public static string UnderscoresToSpaces(string input)


### PR DESCRIPTION
# Texture型のサポートを追加

## 目的

- マテリアルがSubmodule内にあり、変更できない場合にシーン内で簡易的にテクスチャプロパティを変えるため

## 手段

- 実装の形跡のあるInt型対応の実装を参考にTextureのサポート機能を追加

## 備考

ひとまず簡単に実装してみました。1トラック、1クリップでの動作確認のみしています。
Weight処理はInt型のものをそのまま使っています。